### PR TITLE
Set checks if it contains itself. Fixed to check for name parameter.

### DIFF
--- a/src/main/java/javax/jmdns/impl/NameRegister.java
+++ b/src/main/java/javax/jmdns/impl/NameRegister.java
@@ -118,7 +118,7 @@ public interface NameRegister {
                     return hostname != null && hostname.equals(name);
                 case SERVICE:
                     Set<String> names = _serviceNames.get(networkInterface);
-                    return names != null && names.contains(names);
+                    return names != null && names.contains(name);
                 default:
                     // this is trash to keep the compiler happy
                     return false;


### PR DESCRIPTION
Minor change, should be evident that wrong variable is used.