### PR TITLE
Fix a race that can cause JmmDNS.Factory.getInstance() to return a closing JmmDNS object

### DIFF
--- a/src/main/java/javax/jmdns/JmmDNS.java
+++ b/src/main/java/javax/jmdns/JmmDNS.java
@@ -97,14 +97,12 @@ public interface JmmDNS extends Closeable {
          * @return the JmmDNS
          */
         public static JmmDNS getInstance() {
-            if (_instance == null) {
-                synchronized (Factory.class) {
-                    if (_instance == null) {
-                        _instance = JmmDNS.Factory.newJmmDNS();
-                    }
+            synchronized (Factory.class) {
+                if (_instance == null) {
+                    _instance = JmmDNS.Factory.newJmmDNS();
                 }
+                return _instance;
             }
-            return _instance;
         }
 
         /**


### PR DESCRIPTION
This closes #49.

Signed-off-by: Cameron Gutman <aicommander@gmail.com> (github: cgutman)