### PR TITLE
JmDns not responding to sub-type T_ANY request

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSQuestion.java
+++ b/src/main/java/javax/jmdns/impl/DNSQuestion.java
@@ -205,7 +205,9 @@ public class DNSQuestion extends DNSEntry {
                 return;
             }
 
-            this.addAnswersForServiceInfo(jmDNSImpl, answers, (ServiceInfoImpl) jmDNSImpl.getServices().get(loname));
+            for (ServiceInfo serviceInfo : jmDNSImpl.getServices().values()) {
+                this.addAnswersForServiceInfo(jmDNSImpl, answers, (ServiceInfoImpl) serviceInfo);
+            }
         }
 
         @Override


### PR DESCRIPTION
Since subtype name is not a Type, DNSQuestion.AllRecords.addAnswers()
API is not able to get a ServiceInfo instance and fails to answer the
query.

To fetch the ServiceInfo for the relevant SubType, we have to iterate all the registered ServiceInfo and provide the response for incoming request.

Tested with Bonjour Conformance Test tool. Was able to pass the test. 

Fixes #64 
Signed-off-by: Santhosh Kani santhosh.kani@gmail.com (github: SanthoshKani)