### PR TITLE
Host Name Cannot Be User-Defined

### DIFF
--- a/src/main/java/javax/jmdns/impl/HostInfo.java
+++ b/src/main/java/javax/jmdns/impl/HostInfo.java
@@ -89,7 +89,7 @@ public class HostInfo implements DNSStatefulObject {
             if (aName.length() == 0) {
                 aName = addr.getHostName();
             }
-            if (aName.contains("in-addr.arpa") || (aName.equals(addr.getHostAddress()))) {
+            if (aName.contains("in-addr.arpa") || (aName.equals(addr.getHostName()))) {
                 aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : addr.getHostAddress());
             }
         } catch (final IOException e) {


### PR DESCRIPTION
It seems that there is a bug in the javax.jmdns.impl.HostInfo class and its newHostInfo(InetAddress address, JmDNSImpl dns, String jmdnsName) method. In my project it is mandatory to export a gateway as mDNS device with host name using the following pattern:

Miele-.local.

So we are using the following code for the creation of the JmDNS instance for exporting the Gateway:

jmDNS = JmDNS.create(InetAddress.getLocalHost(), hostName);

where the hostName is created according the pattern described above. Using the library the Gateway was always exported with the Host name of the box but not the one which is passed as parameter. I found something which looks like a bug in the newHostInfo method. Here is the original source:

```
public static HostInfo newHostInfo(InetAddress address, JmDNSImpl dns, String jmdnsName) {
    HostInfo localhost = null;
    String aName = (jmdnsName != null ? jmdnsName : "");
    InetAddress addr = address;
    try {
        if (addr == null) {
            String ip = System.getProperty("net.mdns.interface");
            if (ip != null) {
                addr = InetAddress.getByName(ip);
            } else {
                addr = InetAddress.getLocalHost();
                if (addr.isLoopbackAddress()) {
                    // Find local address that isn't a loopback address
                    InetAddress[] addresses = NetworkTopologyDiscovery.Factory.getInstance().getInetAddresses();
                    if (addresses.length > 0) {
                        addr = addresses[0];
                    }
                }
            }
            if (addr.isLoopbackAddress()) {
                logger.warn("Could not find any address beside the loopback.");
            }
        }
        if (aName.length() == 0) {
            aName = addr.getHostName();
        }
        if (aName.contains("in-addr.arpa") || (aName.equals(addr.getHostAddress()))) {
            aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : addr.getHostAddress());
        }
    } catch (final IOException e) {
        logger.warn("Could not intialize the host network interface on " + address + "because of an error: " + e.getMessage(), e);
        // This is only used for running unit test on Debian / Ubuntu
        addr = loopbackAddress();
        aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : "computer");
    }
    // A host name with "." is illegal. so strip off everything and append .local.
    // We also need to be carefull that the .local may already be there
    int index = aName.indexOf(".local");
    if (index > 0) {
        aName = aName.substring(0, index);
    }
    aName = aName.replaceAll("[:%\\.]", "-");
    aName += ".local.";
    localhost = new HostInfo(addr, aName, dns);
    return localhost;
}
```

and here is the fix which we've done:

```
public static HostInfo newHostInfo(InetAddress address, JmDNSImpl dns, String jmdnsName) {
    HostInfo localhost = null;
    String aName = (jmdnsName != null ? jmdnsName : "");
    InetAddress addr = address;
    try {
        if (addr == null) {
            String ip = System.getProperty("net.mdns.interface");
            if (ip != null) {
                addr = InetAddress.getByName(ip);
            } else {
                addr = InetAddress.getLocalHost();
                if (addr.isLoopbackAddress()) {
                    // Find local address that isn't a loopback address
                    InetAddress[] addresses = NetworkTopologyDiscovery.Factory.getInstance().getInetAddresses();
                    if (addresses.length > 0) {
                        addr = addresses[0];
                    }
                }
            }
            if (addr.isLoopbackAddress()) {
                logger.warn("Could not find any address beside the loopback.");
            }
        }
        if (aName.length() == 0) {
            aName = addr.getHostName();
        }
        if (aName.contains("in-addr.arpa") || (aName.equals(addr.getHostName()))) {
            aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : addr.getHostAddress());
        }
    } catch (final IOException e) {
        logger.warn("Could not intialize the host network interface on " + address + "because of an error: " + e.getMessage(), e);
        // This is only used for running unit test on Debian / Ubuntu
        addr = loopbackAddress();
        aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : "computer");
    }
    // A host name with "." is illegal. so strip off everything and append .local.
    // We also need to be carefull that the .local may already be there
    int index = aName.indexOf(".local");
    if (index > 0) {
        aName = aName.substring(0, index);
    }
    aName = aName.replaceAll("[:%\\.]", "-");
    aName += ".local.";
    localhost = new HostInfo(addr, aName, dns);
    return localhost;
}
```

Using this fix now my gateway is always exported using the pattern I want to use. I'd like to ask you to check whether this is really a bug or I'm not using the correct methods.
