### PR TITLE
Use default TTL instead of DNSConstants

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSQuestion.java
+++ b/src/main/java/javax/jmdns/impl/DNSQuestion.java
@@ -15,6 +15,7 @@ import javax.jmdns.impl.JmDNSImpl.ServiceTypeEntry;
 import javax.jmdns.impl.constants.DNSConstants;
 import javax.jmdns.impl.constants.DNSRecordClass;
 import javax.jmdns.impl.constants.DNSRecordType;
+import javax.jmdns.impl.tasks.state.DNSStateTask;
 
 /**
  * A DNS question.
@@ -280,8 +281,8 @@ public class DNSQuestion extends DNSEntry {
     protected void addAnswersForServiceInfo(JmDNSImpl jmDNSImpl, Set<DNSRecord> answers, ServiceInfoImpl info) {
         if ((info != null) && info.isAnnounced()) {
             if (this.getName().equalsIgnoreCase(info.getQualifiedName()) || this.getName().equalsIgnoreCase(info.getType()) || this.getName().equalsIgnoreCase(info.getTypeWithSubtype())) {
-                answers.addAll(jmDNSImpl.getLocalHost().answers(this.getRecordClass(), DNSRecordClass.UNIQUE, DNSConstants.DNS_TTL));
-                answers.addAll(info.answers(this.getRecordClass(), DNSRecordClass.UNIQUE, DNSConstants.DNS_TTL, jmDNSImpl.getLocalHost()));
+                answers.addAll(jmDNSImpl.getLocalHost().answers(this.getRecordClass(), DNSRecordClass.UNIQUE, DNSStateTask.defaultTTL()));
+                answers.addAll(info.answers(this.getRecordClass(), DNSRecordClass.UNIQUE, DNSStateTask.defaultTTL(), jmDNSImpl.getLocalHost()));
             }
             if (logger.isDebugEnabled()) {
                 logger.debug(jmDNSImpl.getName() + " DNSQuestion(" + this.getName() + ").addAnswersForServiceInfo(): info: " + info + "\n" + answers);

--- a/src/test/java/javax/jmdns/test/JmDNSTest.java
+++ b/src/test/java/javax/jmdns/test/JmDNSTest.java
@@ -530,16 +530,17 @@ public class JmDNSTest {
     }
 
     @Test
-    public void testRegisterServiceWithDifferentDefaultTLL() throws IOException, InterruptedException {
-        System.out.println("Unit Test: testRegisterServiceWithDifferentDefaultTLL()");
+    public void testRegisterServiceWithDifferentDefaultTTL() throws IOException, InterruptedException {
+        System.out.println("Unit Test: testRegisterServiceWithDifferentDefaultTTL()");
         JmDNS registry = null;
         int defaultTTL = 30;
         try {
             DNSStateTask.setDefaultTTL(defaultTTL);
             registry = JmDNS.create();
             registry.registerService(service);
-            // Needed - otherwise DNSQuestion.addAnswersForServiceInfo is not called
+            // Needed - otherwise DNSQuestion.addAnswersForServiceInfo is not called and the cache not updated
             ServiceInfo[] services = registry.list(service.getType());
+            assertEquals(service, services[0]);
 
             JmDNSImpl registryImpl = (JmDNSImpl) registry;
             DNSCache cache = registryImpl.getCache();
@@ -550,8 +551,10 @@ public class JmDNSTest {
                     assertTrue(record.getRecordType().toString(), Math.abs(defaultTTL - record.getTTL()) <= 1);
                 }
             }
+            registry.unregisterService(services[0]);
         } finally {
             if (registry != null) registry.close();
+			DNSStateTask.setDefaultTTL(DNSConstants.DNS_TTL);
         }
     }
 }

--- a/src/test/java/javax/jmdns/test/JmDNSTest.java
+++ b/src/test/java/javax/jmdns/test/JmDNSTest.java
@@ -546,7 +546,7 @@ public class JmDNSTest {
             Collection<DNSEntry> entries = cache.allValues();
             for (DNSEntry entry : entries) {
                 DNSRecord record = (DNSRecord) entry;
-                if (record.getRecordType() == DNSRecordType.TYPE_PTR || record.getRecordType() == DNSRecordType.TYPE_SRV || record.getRecordType() == DNSRecordType.TYPE_TXT) {
+                if (record.getRecordType() == DNSRecordType.TYPE_SRV || record.getRecordType() == DNSRecordType.TYPE_TXT) {
                     assertTrue(record.getRecordType().toString(), Math.abs(defaultTTL - record.getTTL()) <= 1);
                 }
             }

--- a/src/test/java/javax/jmdns/test/JmDNSTest.java
+++ b/src/test/java/javax/jmdns/test/JmDNSTest.java
@@ -538,6 +538,8 @@ public class JmDNSTest {
             DNSStateTask.setDefaultTTL(defaultTTL);
             registry = JmDNS.create();
             registry.registerService(service);
+            // Needed - otherwise DNSQuestion.addAnswersForServiceInfo is not called
+            ServiceInfo[] services = registry.list(service.getType());
 
             JmDNSImpl registryImpl = (JmDNSImpl) registry;
             DNSCache cache = registryImpl.getCache();
@@ -545,7 +547,7 @@ public class JmDNSTest {
             for (DNSEntry entry : entries) {
                 DNSRecord record = (DNSRecord) entry;
                 if (record.getRecordType() == DNSRecordType.TYPE_PTR || record.getRecordType() == DNSRecordType.TYPE_SRV || record.getRecordType() == DNSRecordType.TYPE_TXT) {
-                    assertEquals(record.getRecordType().toString(), defaultTTL, record.getTTL());
+                    assertTrue(record.getRecordType().toString(), Math.abs(defaultTTL - record.getTTL()) <= 1);
                 }
             }
         } finally {


### PR DESCRIPTION
By setting DNSStateTask.setDefaultTTL(newDefaultTTLValue) a new default TTL can be set.
But in the code the value of the constant is still used.
It would be helpful if at least in the DNSQuestion class in the method addAnswersForServiceInfo the "DNSConstants.DNS_TTL" value is replaced by "DNSStateTask.defaultTTL()".
With these changes the answer of an DNS question uses the new default TTL value.

As mentioned above their exists similar methods still using the constant value. But I am not sure if all occurrences should be replaced.

Regards
Frank
