### PR TITLE
Fix for java.net.SocketException: setsockopt failed: ENODEV (No such device) on android as on Wifi Hotspot(AP Mode)

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -470,7 +470,10 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
             }
         }
         _socket.setTimeToLive(255);
-        _socket.joinGroup(_group);
+		
+		// To work on Android when is on Wifi hotspot(AP mode).
+		
+        _socket.joinGroup(new InetSocketAddress(_group,DNSConstants.MDNS_PORT),hostInfo.getInterface());
     }
 
     private void closeMulticastSocket() {


### PR DESCRIPTION
Hi,
I'm working with jmdns on Android.

I have problems publishing services when android as on Wifi Hotspot(AP Mode).
It gives me "java.net.SocketException: setsockopt failed: ENODEV (No such device)"

I make one change on method "openMulticastSocket(HostInfo hostInfo)" on "JmDNSImpl" class and now its working.
The change was: Replace "_socket.joinGroup(_group);" with _socket.joinGroup(new InetSocketAddress(_group,DNSConstants.MDNS_PORT),hostInfo.getInterface());

Somebody else had this problem? Can someone try replicate the problem?
