### PR TITLE
Add Maven Central badge status to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![build status](https://travis-ci.org/openhab/jmdns.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jmdns/jmdns/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jmdns/jmdns)
 
 This library is licensed under the Apache License Version 2.0.
 Please see the file [NOTICE.txt](NOTICE.txt).  


### PR DESCRIPTION
Handy way to find the status of latest version deployed to Maven Central.