### PR TITLE
Fixes #93

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -126,7 +126,7 @@ public abstract class DNSRecord extends DNSEntry {
      */
     long getExpirationTime(int percent) {
         // ttl is in seconds the constant 10 is 1000 ms / 100 %
-        return _created + (percent * _ttl * 10L);
+        return _created + (percent * ((long)_ttl) * 10L);
     }
 
     /**


### PR DESCRIPTION
Addresses the integer overflow that could occur for large values of _ttl by first extending it to long before multiplying.

Signed-off-by: Kurt Haenen <kurt.haenen@gmail.com> (github: Misterke)