### PR TITLE
Removed .toLowerCase() on subtype return in getTypeWithSubtype

### DIFF
--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -404,7 +404,7 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
     @Override
     public String getTypeWithSubtype() {
         String subtype = this.getSubtype();
-        return (subtype.length() > 0 ? "_" + subtype.toLowerCase() + "._sub." : "") + this.getType();
+        return (subtype.length() > 0 ? "_" + subtype + "._sub." : "") + this.getType();
     }
 
     /**


### PR DESCRIPTION
Fixes #99. This allows subtypes containing capital letters to be discoverable be services that depend on  them. 

Signed-off-by: Matt Becker matt.s.becker@gmail.com (github: mattsbecker)
