### PR TITLE
Bugfix/DNSRecord.Text off by one

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -662,7 +662,24 @@ public abstract class DNSRecord extends DNSEntry {
         @Override
         protected void toString(StringBuilder aLog) {
             super.toString(aLog);
-            aLog.append(" text: '" + ((_text.length > 20) ? new String(_text, 0, 17) + "..." : new String(_text)) + "'");
+            aLog.append(" text: '");
+
+            // since the first byte of the array contains the length of data bytes
+            // we care only about _text containing real actual data
+            if (_text.length > 2) {
+                // if there is to much text make it short
+                if (_text.length > 21) {
+                    // the first raw byte contains the length of the TXT so we skip it
+                    aLog.append(new String(_text, 1, 17)).append("...");
+                } else {
+                    // just to be sure, whatever is smaller
+                    final int len = Math.min(_text[0], _text.length - 1);
+
+                    // the first raw byte contains the length of the TXT so we skip it
+                    aLog.append(new String(_text, 1, len));
+                }
+            }
+            aLog.append('\'');
         }
 
     }


### PR DESCRIPTION
While changing `toString()` methods of `DNSRecord` subclasses to avoid the creation of additional `String`s a small issue was found which showed a (in most cases) unprintable character befor the content of `DNSRecord.Text`.

This was due to `DNSRecord.Text` having a `byte` array which contains the length of the contained data at `index 0`, so this first `byte` shouldn't be used for `String`  creation.