### PR TITLE
Revert close() logic to previous behavior

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -1890,7 +1890,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
 
         // Stop JmDNS
         // This protects against recursive calls
-        if (this.closeState()) {
+        if (this.cancelState()) {
             // We got the tie break now clean up
 
             // Stop the timer


### PR DESCRIPTION
Fixes #82

Previously, close() put JmDNSImpl into a CANCELING_1 state, which would transition to
CANCELING_2, CANCELING_3, and finally CANCELED.  close() waited the for CANCELED state,
which took about 2 seconds, during which time broadcasts are sent out to remove services
that were advertised.  In Jan 20, 2011 this was changed to put JmDNSImpl into a CLOSING
state, which would transition to CLOSED, but close() still waits for CANCELED, which no
longer happens resulting in a 5 second timeout.  I tried changing to wait for CLOSED,
but then the logic to remove advertised services no longer gets executed.  Reverting to
the orignal logic is safe, and fixes the bug.

Signed-off-by: Ed Tyrrill <etyrrill@gmail.com> (github: etyrrill)