### PR TITLE
Bug fix jmDNS unable to cache-flush when the cache-flush bit is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target/*
 .idea
 *.iml
+p2/features/org\.jmdns\.feature/target/
+
+p2/repository/target/

--- a/p2/features/org.jmdns.feature/feature.xml
+++ b/p2/features/org.jmdns.feature/feature.xml
@@ -1,7 +1,7 @@
 <feature
     id="org.jmdns.feature"
     label="JmDNS"
-    version="3.5.4.qualifier"
+    version="3.5.4.QC1"
     provider-name="JmDNS.org">
 
     <description>

--- a/p2/features/org.jmdns.feature/pom.xml
+++ b/p2/features/org.jmdns.feature/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>features</artifactId>
-        <version>3.5.4-SNAPSHOT</version>
+        <version>3.5.4.QC1</version>
     </parent>
 
     <artifactId>org.jmdns.feature</artifactId>

--- a/p2/features/pom.xml
+++ b/p2/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.4-SNAPSHOT</version>
+        <version>3.5.4.QC1</version>
     </parent>
 
     <artifactId>features</artifactId>

--- a/p2/pom.xml
+++ b/p2/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jmdns.p2</groupId>
     <artifactId>pom</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.5.4.QC1</version>
     <packaging>pom</packaging>
 
     <name>JmDNS p2</name>

--- a/p2/repository/pom.xml
+++ b/p2/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.4-SNAPSHOT</version>
+        <version>3.5.4.QC1</version>
     </parent>
 
     <artifactId>org.jmdns.repository</artifactId>

--- a/p2/targetplatform/pom.xml
+++ b/p2/targetplatform/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.4.QC1</version>
     </parent>
 
     <artifactId>targetplatform</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jmdns</groupId>
 	<artifactId>jmdns</artifactId>
-	<version>3.5.4-SNAPSHOT</version>
+	<version>3.5.4.QC1</version>
 	<name>JmDNS</name>
 	<packaging>jar</packaging>
 	<description>JmDNS is a Java implementation of multi-cast DNS and can be used for service registration and discovery in local area networks. JmDNS is fully compatible with Apple's Bonjour.

--- a/src/main/java/javax/jmdns/impl/DNSCache.java
+++ b/src/main/java/javax/jmdns/impl/DNSCache.java
@@ -273,18 +273,18 @@ public class DNSCache extends ConcurrentHashMap<String, List<DNSEntry>> {
     @Override
     public synchronized String toString() {
         final StringBuilder sb = new StringBuilder(2000);
-        sb.append("\n\t---- cache ----");
-        for(final Map.Entry<String, List<DNSEntry>> entry : this.entrySet()) {
-            sb.append("\n\n\t\tname '").append(entry.getKey()).append('\'');
-            final List<DNSEntry> entryList = entry.getValue();
+        sb.append("\t---- cache ----");
+        for (final Map.Entry<String, List<DNSEntry>> entry : this.entrySet()) {
+            sb.append("\n\n\t\tname '").append(entry.getKey()).append("' ");
+            final List<? extends DNSEntry> entryList = entry.getValue();
             if ((entryList != null) && (!entryList.isEmpty())) {
                 synchronized (entryList) {
-                    for (DNSEntry dnsEntry : entryList) {
+                    for (final DNSEntry dnsEntry : entryList) {
                         sb.append("\n\t\t\t").append(dnsEntry.toString());
                     }
                 }
             } else {
-                sb.append(" : no entries");
+                sb.append(": no entries");
             }
         }
         return sb.toString();

--- a/src/main/java/javax/jmdns/impl/DNSEntry.java
+++ b/src/main/java/javax/jmdns/impl/DNSEntry.java
@@ -299,7 +299,7 @@ public abstract class DNSEntry {
         sb.append('[').append(this.getClass().getSimpleName()).append('@').append(System.identityHashCode(this));
         sb.append(" type: ").append(this.getRecordType());
         sb.append(", class: ").append(this.getRecordClass());
-        sb.append((_unique ? "-unique," : ","));
+        sb.append((_unique ? ", flush cache," : ","));
         sb.append(" name: ").append( _name);
         this.toString(sb);
         sb.append(']');

--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -1078,4 +1078,9 @@ public abstract class DNSRecord extends DNSEntry {
     public int getTTL() {
         return _ttl;
     }
+
+    public long getCreated() {
+        return this._created;
+    }
+
 }

--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -670,14 +670,24 @@ public abstract class DNSRecord extends DNSEntry {
             super.toString(sb);
             sb.append(" text: '");
 
-            final String text = ByteWrangler.readUTF(_text);
+            // since the first byte of the array contains the length of data bytes
+            // we care only about _text containing real actual data
+            if (_text.length > 2) {
+                // if there is to much text make it short
+                // 20 characters + 1 length byte
+                if (_text.length > 21) {
+                    // the first raw byte contains the length of the TXT so we skip it
+                    // we want only 17 characters an append 3 dots
+                    final String str = ByteWrangler.readUTF(_text, 1, 17);
+                    sb.append(str).append("...");
+                } else {
+                    // just to be sure, whatever is smaller
+                    final int len = Math.min(_text[0], _text.length - 1);
 
-            // if the text is longer than 20 characters cut it to 17 chars
-            // and add "..." at the end
-            if (20 < text.length()) {
-                sb.append(text, 0, 17).append("...");
-            } else {
-                sb.append(text);
+                    final String str = ByteWrangler.readUTF(_text, 1, len);
+                    // the first raw byte contains the length of the TXT so we skip it
+                    sb.append(str);
+                }
             }
             sb.append('\'');
         }

--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -763,6 +763,96 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
         return info;
     }
 
+    /**
+     * This is a rather brute force approach to scan the cache for related DNSEntry objects 
+     * @param info
+     * @return
+     */
+    boolean removeServiceInfoFromCache(final ServiceInfoImpl info) {
+        if (null == info) {
+            logger.error("Cannot remove null ServiceInfo");
+            return false;
+        }
+
+        boolean changed = false;
+
+        final String key = info.getKey();
+
+        this.getCache().logCachedContent();
+
+        // remove all entries associated with this type
+        final Collection<? extends DNSEntry> removedEntries = this.getCache().remove(key);
+        if (null != removedEntries) {
+            changed = true;
+        }
+
+        logger.trace("Removed entries from cache for type {}: {}", key, removedEntries);
+
+        // get all related keys from the removed entry
+        final Set<String> otherKeys = new HashSet<String>();
+        for (final DNSEntry dnsEntry : removedEntries) {
+            if (dnsEntry instanceof DNSRecord.Text) {
+                final DNSRecord.Text text = (DNSRecord.Text) dnsEntry;
+                final String name = text.getName().toLowerCase();
+                otherKeys.add(name);
+                logger.trace("Added key {} from {}", name, text);
+            } else if (dnsEntry instanceof DNSRecord.Pointer) {
+                final DNSRecord.Pointer pointer = (DNSRecord.Pointer) dnsEntry;
+                final String alias = pointer.getAlias().toLowerCase();
+                otherKeys.add(alias);
+                logger.trace("Added key {} from {}", alias, pointer);
+            } else if (dnsEntry instanceof DNSRecord.HostInformation) {
+                final DNSRecord.HostInformation hostInformation = (DNSRecord.HostInformation) dnsEntry;
+                final String name = hostInformation.getName().toLowerCase();
+                otherKeys.add(name);
+                logger.trace("Added key {} from {}", name, hostInformation);
+            } else if (dnsEntry instanceof DNSRecord.Service) {
+                final DNSRecord.Service service = (DNSRecord.Service) dnsEntry;
+                final String server = service.getServer().toLowerCase();
+                otherKeys.add(server);
+                logger.trace("Added key {} from {}", server, service);
+            }
+        }
+
+        // now search for all these related keys and remove them from the cache...
+        final Collection<? extends DNSEntry> dnsEntries = this.getCache().allValues();
+        for (final DNSEntry dnsEntry : dnsEntries) {
+            if (dnsEntry instanceof DNSRecord.Text) {
+                final DNSRecord.Text text = (DNSRecord.Text) dnsEntry;
+                final String name = text.getName().toLowerCase();
+                if (otherKeys.contains(name)) {
+                    this.getCache().removeDNSEntry(text);
+                    changed = true;
+                }
+            } else if (dnsEntry instanceof DNSRecord.Pointer) {
+                final DNSRecord.Pointer pointer = (DNSRecord.Pointer) dnsEntry;
+                final String alias = pointer.getAlias().toLowerCase();
+                if (otherKeys.contains(alias)) {
+                    this.getCache().removeDNSEntry(pointer);
+                    changed = true;
+                }
+            } else if (dnsEntry instanceof DNSRecord.HostInformation) {
+                final DNSRecord.HostInformation hostInformation = (DNSRecord.HostInformation) dnsEntry;
+                final String name = hostInformation.getName().toLowerCase();
+                if (otherKeys.contains(name)) {
+                    this.getCache().removeDNSEntry(hostInformation);
+                    changed = true;
+                }
+            } else if (dnsEntry instanceof DNSRecord.Service) {
+                final DNSRecord.Service service = (DNSRecord.Service) dnsEntry;
+                final String server = service.getServer().toLowerCase();
+                if (otherKeys.contains(server)) {
+                    this.getCache().removeDNSEntry(service);
+                    changed = true;
+                }
+            }
+        }
+
+        this.getCache().logCachedContent();
+
+        return changed;
+    }
+
     ServiceInfoImpl getServiceInfoFromCache(String type, String name, String subtype, boolean persistent) {
         // Check if the answer is in the cache.
         ServiceInfoImpl info = new ServiceInfoImpl(type, name, subtype, 0, 0, 0, persistent, (byte[]) null);
@@ -893,6 +983,54 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
                             listener.serviceResolved(localEvent);
                         }
                     });
+                }
+            }
+        }
+    }
+
+    /**
+     * Informs all registered {@link ServiceListener}s with an {@link ServiceEvent} about a removed {@link ServiceInfo}.
+     *
+     * @param event
+     *            containing the {@link ServiceInfo} which was resolved
+     */
+    void handleServiceRemoved(final ServiceEvent event) {
+        final String serviceType = event.getType().toLowerCase();
+
+        final List<ServiceListenerStatus> list = _serviceListeners.get(serviceType);
+
+        logger.debug("Service removed: {}", event.getInfo().getKey());
+
+        // we might have some listeners to inform
+        if (list != null)  {
+            if (event.getInfo() != null) {
+                logger.debug("Service removed: {}", event.getInfo().getKey());
+                if (event.getInfo().hasData()) {
+                    logger.trace("Service to be removed, still contains data in ServiceInfo: {}", event.getInfo());
+                } else {
+                    // handle only services which have no "valid" data (anymore)
+                    // the ServiceInfo might be removed _because_ there is no data => service not available anymore
+                    final List<ServiceListenerStatus> listCopy;
+                    synchronized (list) {
+                        if ( list.isEmpty() ) {
+                            // no listeners found => nothing to do
+                            logger.trace("No ServiceListener found for removal of ServiceInfo: {}", event.getInfo());
+                            return;
+                        }
+                        listCopy = new ArrayList<ServiceListenerStatus>(list);
+                    }
+
+                    logger.trace("Service removed, calling listeners ({})", listCopy.size());
+
+                    for (final ServiceListenerStatus listener : listCopy) {
+                        _executor.submit(new Runnable() {
+                            /** {@inheritDoc} */
+                            @Override
+                            public void run() {
+                                listener.serviceRemoved(event);
+                            }
+                        });
+                    }
                 }
             }
         }
@@ -1159,12 +1297,14 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
                 if (DNSRecordType.TYPE_SRV.equals(dnsEntry.getRecordType()) && !dnsEntry.isExpired(now)) {
                     final DNSRecord.Service s = (DNSRecord.Service) dnsEntry;
                     if (s.getPort() != info.getPort() || !s.getServer().equals(_localHost.getName())) {
-                        logger.debug("makeServiceNameUnique() JmDNS.makeServiceNameUnique srv collision:{} s.server={} {} equals:{}",
-                                dnsEntry,
-                                s.getServer(),
-                                _localHost.getName(),
-                                s.getServer().equals(_localHost.getName())
-                        );
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("makeServiceNameUnique() JmDNS.makeServiceNameUnique srv collision:{} s.server={} {} equals:{}",
+                                    dnsEntry,
+                                    s.getServer(),
+                                    _localHost.getName(),
+                                    s.getServer().equals(_localHost.getName())
+                            );
+                        }
                         info.setName(NameRegister.Factory.getRegistry().incrementName(_localHost.getInetAddress(), info.getName(), NameRegister.NameType.SERVICE));
                         collision = true;
                         break;
@@ -1287,12 +1427,16 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
             } else {
                 serviceListenerList = Collections.emptyList();
             }
-            logger.trace("{}.updating record for event: {} list {} operation: {}",
-                this.getName(),
-                event,
-                serviceListenerList,
-                operation
-            );
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("{}.updating record for event: {} list {} operation: {}",
+                    this.getName(),
+                    event,
+                    serviceListenerList,
+                    operation
+                );
+            }
+          
             if (!serviceListenerList.isEmpty()) {
                 final ServiceEvent localEvent = event;
 
@@ -1346,6 +1490,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
             final boolean unique = newRecord.isUnique();
             final DNSRecord cachedRecord = (DNSRecord) this.getCache().getDNSEntry(newRecord);
             logger.debug("{} handle response cached record: {}", this.getName(), cachedRecord);
+
             // RFC 6762, section 10.2 Announcements to Flush Outdated Cache Entries
             // https://tools.ietf.org/html/rfc6762#section-10.2
             // if (cache-flush a.k.a unique), remove all existing records matching these criterias :--

--- a/src/main/java/javax/jmdns/impl/NetworkTopologyEventImpl.java
+++ b/src/main/java/javax/jmdns/impl/NetworkTopologyEventImpl.java
@@ -60,13 +60,14 @@ public class NetworkTopologyEventImpl extends NetworkTopologyEvent implements Cl
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        sb.append('[').append(this.getClass().getSimpleName()).append('@').append(System.identityHashCode(this))
-            .append("\n\tinetAddress: '")
-            .append(this.getInetAddress())
+
+        sb.append('[')
+            .append(this.getClass().getSimpleName()).append('@').append(System.identityHashCode(this))
+            .append("\n\tInetAddress: '").append(this.getInetAddress())
             .append("']");
-//            .append("' source: ")
-//            .append("\n\t" + source + "")
-//            .append("\n]");
+        // buf.append("' source: ");
+        // buf.append("\n\t" + source + "");
+        // buf.append("\n]");
         return sb.toString();
     }
 

--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -59,6 +59,11 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
     private final Set<Inet4Address> _ipv4Addresses;
     private final Set<Inet6Address> _ipv6Addresses;
 
+    /**
+     * Flag to track if an InetAddress was set at least once
+     */
+    private boolean                 _inetAddressSet = false;
+
     private transient String        _key;
 
     private boolean                 _persistent;
@@ -1220,7 +1225,6 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
             }
         }
         sb.append(']');
-
         return sb.toString();
     }
 

--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -795,6 +795,7 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
         // flag for changes
         boolean serviceChanged = false;
 
+        // When a record is soon to be expired, i.e. ttl=1, consider that as expired too. 
         if (record.isExpired(now)) {
             // remove data
             serviceChanged = handleExpiredRecord(record);
@@ -813,7 +814,18 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
                     // ServiceEvent event = ((DNSRecord) rec).getServiceEvent(dns);
                     // event = new ServiceEventImpl(dns, event.getType(), event.getName(), this);
                     // Failure to resolve services - ID: 3517826
-                    ServiceEvent event = new ServiceEventImpl(dns, this.getType(), this.getName(), this);
+                    //
+                    // There is a timing/ concurrency issue here.  The ServiceInfo object is subject to concurrent change.
+                    // e.g. when a device announce a new IP, the old IP has TTL=1.
+                    //
+                    // The listeners runs on different threads concurrently. When they start and read the event,
+                    // the ServiceInfo is already removed/ changed.
+                    //
+                    // The simple solution is to clone the ServiceInfo.  Therefore, future changes to ServiceInfo 
+                    // will not be seen by the listeners.
+                    //
+                    // Fixes ListenerStatus warning "Service Resolved called for an unresolved event: {}"
+                    ServiceEvent event = new ServiceEventImpl(dns, this.getType(), this.getName(), this.clone());
                     dns.handleServiceResolved(event);
                 }
             } else {

--- a/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
@@ -53,6 +53,7 @@ public final class DNSConstants {
     public static final int    RECORD_EXPIRY_DELAY            = 1;                                                            // This is 1s delay used in ttl and therefore in seconds
     public static final int    KNOWN_ANSWER_TTL               = 120;
     public static final int    ANNOUNCED_RENEWAL_TTL_INTERVAL = DNS_TTL * 500;                                                // 50% of the TTL in milliseconds
+    public static final int    FLUSH_RECORD_OLDER_THAN_1_SECOND  = 1;                                                         // rfc6762, section 10.2 Flush outdated cache (older than 1 second)
 
     public static final int    STALE_REFRESH_INCREMENT           = 5;
     public static final int    STALE_REFRESH_STARTING_PERCENTAGE = 80;

--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordClass.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordClass.java
@@ -132,7 +132,7 @@ public enum DNSRecordClass {
 
     @Override
     public String toString() {
-        return this.name() + " index " + this.indexValue();
+        return _externalName.toUpperCase();
     }
 
 }

--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
@@ -307,7 +307,7 @@ public enum DNSRecordType {
 
     @Override
     public String toString() {
-        return this.name() + " index " + this.indexValue();
+        return this._externalName.toUpperCase();
     }
 
 }

--- a/src/test/java/javax/jmdns/util/test/ByteWranglerTest.java
+++ b/src/test/java/javax/jmdns/util/test/ByteWranglerTest.java
@@ -1,6 +1,10 @@
 package javax.jmdns.util.test;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+
+import java.util.Random;
+import java.util.UUID;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
Summary: Implementation did not follow closely to the RFC-6762 section 10.2 description and is fixed.

Description: we have tested that the jmdns is unable to cope with IP address change of one of our D-LINK camera 2330L.  This is because the jmdns library had a minor mistake in the cache-flush implementation.  It has be fixed to follow as described as RFC-6762 section 10.2

The fix is currently under testing.   The PR is created for early comments.  Will post again when tested on more devices.

Signed-off-by: Gary Tse <gary.tse@telekom.de>