### PR TITLE
Bugfix Issue#95 stale ip address still reported + Fix warnings for listener events

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -1078,4 +1078,9 @@ public abstract class DNSRecord extends DNSEntry {
     public int getTTL() {
         return _ttl;
     }
+
+    public long getCreated() {
+        return this._created;
+    }
+
 }

--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -795,6 +795,7 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
         // flag for changes
         boolean serviceChanged = false;
 
+        // When a record is soon to be expired, i.e. ttl=1, consider that as expired too. 
         if (record.isExpired(now)) {
             // remove data
             serviceChanged = handleExpiredRecord(record);
@@ -813,7 +814,18 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
                     // ServiceEvent event = ((DNSRecord) rec).getServiceEvent(dns);
                     // event = new ServiceEventImpl(dns, event.getType(), event.getName(), this);
                     // Failure to resolve services - ID: 3517826
-                    ServiceEvent event = new ServiceEventImpl(dns, this.getType(), this.getName(), this);
+                    //
+                    // There is a timing/ concurrency issue here.  The ServiceInfo object is subject to concurrent change.
+                    // e.g. when a device announce a new IP, the old IP has TTL=1.
+                    //
+                    // The listeners runs on different threads concurrently. When they start and read the event,
+                    // the ServiceInfo is already removed/ changed.
+                    //
+                    // The simple solution is to clone the ServiceInfo.  Therefore, future changes to ServiceInfo 
+                    // will not be seen by the listeners.
+                    //
+                    // Fixes ListenerStatus warning "Service Resolved called for an unresolved event: {}"
+                    ServiceEvent event = new ServiceEventImpl(dns, this.getType(), this.getName(), this.clone());
                     dns.handleServiceResolved(event);
                 }
             } else {

--- a/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
@@ -53,6 +53,7 @@ public final class DNSConstants {
     public static final int    RECORD_EXPIRY_DELAY            = 1;                                                            // This is 1s delay used in ttl and therefore in seconds
     public static final int    KNOWN_ANSWER_TTL               = 120;
     public static final int    ANNOUNCED_RENEWAL_TTL_INTERVAL = DNS_TTL * 500;                                                // 50% of the TTL in milliseconds
+    public static final int    FLUSH_RECORD_OLDER_THAN_1_SECOND  = 1;                                                         // rfc6762, section 10.2 Flush outdated cache (older than 1 second)
 
     public static final int    STALE_REFRESH_INCREMENT           = 5;
     public static final int    STALE_REFRESH_STARTING_PERCENTAGE = 80;


### PR DESCRIPTION
1. Issue#95 Fix cache-flush to follow mdns specification (RFC 6762, section 10.2 Announcements to Flush Outdated Cache Entries)

2. Fix warnings for listener events 
After fixing the cache-flush, ListenerStatus frequently fires new warnings "Service Resolved called for an unresolved event: {}".  This is caused by concurrent modification of the ServiceInfo object.