### PR TITLE
Fix bug causing getServer() to always be empty (#164)

### DIFF
--- a/src/main/java/javax/jmdns/ServiceInfo.java
+++ b/src/main/java/javax/jmdns/ServiceInfo.java
@@ -436,10 +436,18 @@ public abstract class ServiceInfo implements Cloneable {
 
     /**
      * Get the name of the server.
+     * <b>Note:</b> This will be an empty string if no value has been set
      * 
      * @return server name
      */
     public abstract String getServer();
+
+    /**
+     * Returns true if the service info has a server
+     *
+     * @return <code>true</code> if the service info has a server specified, <code>false</code> otherwise.
+     */
+    public abstract boolean hasServer();
 
     /**
      * Returns the host IP address string in textual presentation.<br/>

--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -452,6 +452,14 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
     }
 
     /**
+     * @see javax.jmdns.ServiceInfo#hasServer()
+     */
+    @Override
+    public boolean hasServer() {
+        return (this._server != null);
+    }
+
+    /**
      * @param server
      *            the server to set
      */
@@ -894,7 +902,7 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
      * @param dnsCache
      * @param now
      * @param record to get data from
-     * @return
+     * @return <code>true</code> if service was updated, <code>false</code> otherwise
      */
     private boolean handleUpdateRecord(final DNSCache dnsCache, final long now, final DNSRecord record) {
 
@@ -974,7 +982,7 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
      */
     @Override
     public synchronized boolean hasData() {
-        return this.getServer() != null && this.hasInetAddress() && this.getTextBytes() != null && this.getTextBytes().length > 0;
+        return this.hasServer() && this.hasInetAddress() && this.getTextBytes() != null && this.getTextBytes().length > 0;
         // return this.getServer() != null && (this.getAddress() != null || (this.getTextBytes() != null && this.getTextBytes().length > 0));
     }
 
@@ -1165,6 +1173,7 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
     @Override
     public ServiceInfoImpl clone() {
         ServiceInfoImpl serviceInfo = new ServiceInfoImpl(this.getQualifiedNameMap(), _port, _weight, _priority, _persistent, _text);
+        serviceInfo.setServer(_server);
         Inet6Address[] ipv6Addresses = this.getInet6Addresses();
         for (Inet6Address address : ipv6Addresses) {
             serviceInfo._ipv6Addresses.add(address);


### PR DESCRIPTION
Fix a couple of bugs that caused ServiceInfo.getServer() to
always return an empty string when processing a resolved Service.
- ServiceInfoImpl.clone() didn't include _server
- ServiceInfoImpl.hasData() failed to properly check for _server being set