### PR TITLE
Allow escape of dot in instance name

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSOutgoing.java
+++ b/src/main/java/javax/jmdns/impl/DNSOutgoing.java
@@ -117,7 +117,7 @@ public final class DNSOutgoing extends DNSMessage {
         void writeName(String name, boolean useCompression) {
             String aName = name;
             while (true) {
-                int n = aName.indexOf('.');
+                int n = indexOfSeparator(aName);
                 if (n < 0) {
                     n = aName.length();
                 }
@@ -125,7 +125,7 @@ public final class DNSOutgoing extends DNSMessage {
                     writeByte(0);
                     return;
                 }
-                String label = aName.substring(0, n);
+                String label = aName.substring(0, n).replace("\\.", ".");
                 if (useCompression && USE_DOMAIN_NAME_COMPRESSION) {
                     Integer offset = _out._names.get(aName);
                     if (offset != null) {
@@ -143,6 +143,22 @@ public final class DNSOutgoing extends DNSMessage {
                 if (aName.startsWith(".")) {
                     aName = aName.substring(1);
                 }
+            }
+        }
+
+        private static int indexOfSeparator(String aName) {
+            int offset = 0;
+            int n = 0;
+
+            while (true) {
+                n = aName.indexOf('.', offset);
+                if (n < 0)
+                    return -1;
+
+                if (n == 0 || aName.charAt(n - 1) != '\\')
+                    return n;
+
+                offset = n + 1;
             }
         }
 


### PR DESCRIPTION
Allow dots in instance names as per rfc 6763. According to rfc6763 instance names are allowed to contain any characters, including dots. They recommend escaping them if concatenating all the parts internally. 

See section 4.3:
”4.3.  Internal Handling of Names”
https://github.com/jmdns/jmdns/blob/master/devdocs/txt/rfc6763.txt

Also see this from avahi: 
“Notes on DNS Name Escaping”
https://code.woboq.org/qt5/include/avahi-compat-libdns_sd/dns_sd.h.html

The reason for this requested support is that the European ITxPT public transport standard is using an additional extra field in the instance containing the separator dot.

While the loop with the separate fields could use a string split with a regexp instead this pull request preserves the code flow as it currently stands.
Otherwise a suggested change could be to split up the concatenated FQDN (aName) with this:
`String[] nameParts = name.split("(?<!\\\\)\\."); // negative look behind, look for \\. (escaped regexp .) without a preceding backslash.`

A complete change should involve checking for (replacing) a double backslash as well. Maybe simply changing line 128 with an additional replace:
`aName.substring(0, n).replace("\\.", ".").replace("\\\\", "\\");`