### PR TITLE
Added a Thread.sleep in SocketListener#run method in order to allow o…

### DIFF
--- a/src/main/java/javax/jmdns/JmDNS.java
+++ b/src/main/java/javax/jmdns/JmDNS.java
@@ -147,12 +147,21 @@ public abstract class JmDNS implements Closeable {
      *            IP address to bind to.
      * @param name
      *            name of the newly created JmDNS
+     * @param threadSleepDurationMs
+     *            time in milliseconds that the JmDNS listener thread should sleep between multicast receives
      * @return jmDNS instance
      * @exception IOException
      *                if an exception occurs during the socket creation
      */
+    public static JmDNS create(final InetAddress addr, final String name, long threadSleepDurationMs) throws IOException {
+        return new JmDNSImpl(addr, name, threadSleepDurationMs);
+    }
+
+    /**
+     * {@link #create(InetAddress, String, long)}. Default value for threadSleepDurationMs parameter is 0.
+     */
     public static JmDNS create(final InetAddress addr, final String name) throws IOException {
-        return new JmDNSImpl(addr, name);
+        return new JmDNSImpl(addr, name, 0);
     }
 
     /**
@@ -359,7 +368,6 @@ public abstract class JmDNS implements Closeable {
      * <pre>
      * Clients receiving a Multicast DNS Response with a TTL of zero SHOULD NOT immediately delete the record from the cache, but instead record a TTL of 1 and then delete the record one second later.
      * </pre>
-     *
      * </p>
      *
      * @param info

--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -106,6 +106,8 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
     private final ConcurrentMap<String, ServiceTypeEntry> _serviceTypes;
 
     private volatile Delegate _delegate;
+    
+    protected final long _threadSleepDurationMs;
 
     /**
      * This is used to store type entries. The type is stored as a call variable and the map support the subtypes.
@@ -394,6 +396,20 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
      * @exception IOException
      */
     public JmDNSImpl(InetAddress address, String name) throws IOException {
+        this(address, name, 0L);
+    }
+    /**
+     * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
+     *
+     * @param address
+     *            IP address to bind to.
+     * @param name
+     *            name of the newly created JmDNS
+     * @param threadSleepDurationMs
+     *            time in milliseconds that the JmDNS listener thread should sleep between multicast receives
+     * @exception IOException
+     */
+    public JmDNSImpl(InetAddress address, String name, long threadSleepDurationMs) throws IOException {
         super();
         logger.debug("JmDNS instance created");
 
@@ -409,6 +425,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
 
         _localHost = HostInfo.newHostInfo(address, this, name);
         _name = (name != null ? name : _localHost.getName());
+        _threadSleepDurationMs = threadSleepDurationMs;
 
         // _cancelerTimer = new Timer("JmDNS.cancelerTimer");
 


### PR DESCRIPTION
…ther threads to get some CPU time if the current subnet is flooded with MDNS traffic.

The amount of time to sleep can be specified as a method argument of JmDNS#create method. If this argument is not used it defaults to 0 and no Thread.sleep calls is invoked.

Signed-off-by: Ivan Iliev <ivan.iliev@musala.com>