### PR TITLE
Added https type 65 to DNSRecordType

### DIFF
--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
@@ -205,6 +205,10 @@ public enum DNSRecordType {
      */
     TYPE_DNSKEY("dnskey", 48),
     /**
+     * HTTPS [draft-ietf-dnsop-svcb-https-00]
+     */
+    TYPE_HTTPS("https", 65),
+    /**
      * [IANA-Reserved]
      */
     TYPE_UINFO("uinfo", 100),


### PR DESCRIPTION
When using Safari on MacOs 11, I got an error in jmdns. From this site
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
I found is is HTTPS, in a draft version of a rfc
https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/00/

This pull request prevents Exceptions to be throws for unknown index type, for example:
"WARN javax.jmdns.impl.constants.DNSRecordType - Could not find record type for index: 65"
"WARN javax.jmdns.impl.DNSIncoming - Could not find record type: dns[query,192.168.178.4:5353, length=31, id=0x0]
    0: 0000000000010000 00000000076f7065 6e686162056c6f63 616c0000418001       ........ .....ope nhab.loc al..A.."