### PR TITLE
Allow overriding for JmDNS instance creation inside JmmDNSImpl

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmmDNSImpl.java
@@ -629,7 +629,7 @@ public class JmmDNSImpl implements JmmDNS, NetworkTopologyListener, ServiceInfoI
             if (!_knownMDNS.containsKey(address)) {
                 synchronized (_knownMDNS) {
                     if (!_knownMDNS.containsKey(address)) {
-                        final JmDNS dns = JmDNS.create(address);
+                        final JmDNS dns = createJmDnsInstance(address);
                         if (_knownMDNS.putIfAbsent(address, dns) == null) {
                             // We need to register the services and listeners with the new JmDNS
                             final Collection<String> types = _serviceTypes;
@@ -783,6 +783,11 @@ public class JmmDNSImpl implements JmmDNS, NetworkTopologyListener, ServiceInfoI
             }
         }
 
+    }
+
+    protected JmDNS createJmDnsInstance(InetAddress address) throws IOException
+    {
+        return JmDNS.create(address);
     }
 
 }


### PR DESCRIPTION
Resolves #215

You can replace the JmDNS instance creation by subclassing JmmDnsImpl

```java
import java.io.IOException;
import java.net.InetAddress;

import javax.jmdns.JmDNS;
import javax.jmdns.impl.JmmDNSImpl;

public class FastJmmDnsImpl extends JmmDNSImpl
{
    private static final String COMPUTER_NAME = System.getenv("COMPUTERNAME");

    @Override
    protected JmDNS createJmDnsInstance(InetAddress address) throws IOException
    {
        return JmDNS.create(address, COMPUTER_NAME);
    }
}
```

and then passing this class as the JmmDNS ClassDelegate:

```java
JmmDNS.Factory.setClassDelegate(FastJmmDnsImpl::new);
```