### PR TITLE
getServiceInfo returns null sometimes

### DIFF
--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -764,14 +764,13 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
                     ServiceEvent event = new ServiceEventImpl(dns, this.getType(), this.getName(), this.clone());
                     dns.handleServiceResolved(event);
                 }
+                // This is done, to notify the wait loop in method JmDNS.waitForInfoData(ServiceInfo info, int timeout);
+                synchronized (this) {
+                    this.notifyAll();
+                }
             } else {
                 logger.debug("JmDNS not available.");
             }
-        }
-
-        // This is done, to notify the wait loop in method JmDNS.waitForInfoData(ServiceInfo info, int timeout);
-        synchronized (this) {
-            this.notifyAll();
         }
     }
 


### PR DESCRIPTION
JmDNS instance invokes getServiceInfo,  but did not wait for enough time, then returned null value.  

When the ServiceInfo's updateRecord method was invoked, even if there is not any data change in this ServiceInfo,  It will notify all the threads which wait  at the ServiceInfo.  That's why the  wait method in waitForInfoData was awaken unexpected.

The correct behavior is:   The ServiceInfo will not notifyAll if there is not any data change.  If there is data change, the ServiceInfo will notify that it is changed.  Then the info.wait(200) in waitForInfoData will be notified.