### PR TITLE
Always perform NetworkChecker task in background

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmmDNSImpl.java
@@ -752,8 +752,7 @@ public class JmmDNSImpl implements JmmDNS, NetworkTopologyListener, ServiceInfoI
 
         public void start(Timer timer) {
             // Run once up-front otherwise the list of servers will only appear after a delay.
-            run();
-            timer.schedule(this, DNSConstants.NETWORK_CHECK_INTERVAL, DNSConstants.NETWORK_CHECK_INTERVAL);
+            timer.schedule(this, 0, DNSConstants.NETWORK_CHECK_INTERVAL);
         }
 
         /**


### PR DESCRIPTION
On modern macOS versions, the `NetworkChecker` can take a long time to finish.

This lets the Timer perform the check in background immediately after invocation, instead of blocking the Initializers by calling `run()` directly.