### PR TITLE
Taking the version of SLF4J-API to latest available at this moment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>1.7.36</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Version 1.7.25 is already 3 years old, and Synopsis Detect is giving operational risk on it.