### PR TITLE
Add actions for GitHub

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main", "addActionsForGithub" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ "main", "addActionsForGithub" ]
   pull_request:
-    branches: [ "main", "addActionsForGithub" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main", "addActionsForGithub" ]
+  pull_request:
+    branches: [ "main", "addActionsForGithub" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+


### PR DESCRIPTION
This is an initial drop of GitHub Actions to allow maven building/validation of push/pull directly on GitHub.

Note that `Dependency graph` must be enabled for the repository to allow the action to successfully build.

```
On GitHub.com, navigate to the main page of the repository.

Under your repository name, click
Settings. If you cannot see the "Settings" tab, select the

dropdown menu, then click Settings. Screenshot of a repository header showing the tabs. The "Settings" tab is highlighted by a dark orange outline.

In the "Security" section of the sidebar, click

Code security and analysis.

Read the message about granting GitHub read-only access to the repository data to enable the dependency graph, then next to "Dependency Graph", click Enable.
```