### PR TITLE
Improve support to atype service type

### DIFF
--- a/src/main/java/javax/jmdns/impl/ServiceTypeDecoder.java
+++ b/src/main/java/javax/jmdns/impl/ServiceTypeDecoder.java
@@ -11,6 +11,8 @@ class ServiceTypeDecoder {
     private static final Pattern SUBTYPE_PATTERN = Pattern.compile("^((.*)\\._)?_?(.*)\\._sub\\._([^.]*)\\._([^.]*)\\.(.*)\\.?$");
     private static final Pattern PATTERN = Pattern.compile("^((.*)?\\._)?([^.]*)\\._([^.]*)\\.(.*)\\.?$");
 
+    private static final Pattern TYPE_A_PATTERN = Pattern.compile("^([^.]*)\\.(.*)\\.?$");
+
     private ServiceTypeDecoder() {
     }
 
@@ -40,11 +42,6 @@ class ServiceTypeDecoder {
             name = ServiceInfoImpl.removeSeparators(casePreservedType.substring(0, index));
             domain = casePreservedType.substring(index);
             application = "";
-        } else if ((!aType.contains("_")) && aType.contains(".")) {
-            index = aType.indexOf('.');
-            name = ServiceInfoImpl.removeSeparators(casePreservedType.substring(0, index));
-            domain = ServiceInfoImpl.removeSeparators(casePreservedType.substring(index));
-            application = "";
         } else {
             Matcher subType = SUBTYPE_PATTERN.matcher(aType);
             if (subType.matches()) {
@@ -60,6 +57,13 @@ class ServiceTypeDecoder {
                     application = originalCase(casePreservedType, normalMatcher, 3);
                     protocol = originalCase(casePreservedType, normalMatcher, 4);
                     domain = originalCase(casePreservedType, normalMatcher, 5);
+                } else {
+                    Matcher aTypeMatcher = TYPE_A_PATTERN.matcher(aType);
+                    if (aTypeMatcher.matches()) {
+                        name = originalCase(casePreservedType, aTypeMatcher, 1);
+                        domain = originalCase(casePreservedType, aTypeMatcher, 2);
+                        application = "";
+                    }
                 }
             }
         }

--- a/src/test/java/javax/jmdns/impl/ServiceTypeDecoderTest.java
+++ b/src/test/java/javax/jmdns/impl/ServiceTypeDecoderTest.java
@@ -34,7 +34,7 @@ public class ServiceTypeDecoderTest {
     @Test
     public void decode() {
         Map<ServiceInfo.Fields, String> actual = ServiceTypeDecoder.decodeQualifiedNameMapForType("DIST123_7-F07_OC030_05_03941.local.");
-        Map<ServiceInfo.Fields, String> expected = ServiceInfoImpl.createQualifiedMap("", "dist123_7-f07_oc030_05_03941.local", "", "", "");
+        Map<ServiceInfo.Fields, String> expected = ServiceInfoImpl.createQualifiedMap("DIST123_7-F07_OC030_05_03941", "", "", "local", "");
         assertEquals(expected, actual);
     }
 
@@ -223,6 +223,32 @@ public class ServiceTypeDecoderTest {
         assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
         assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
         assertEquals("We did not get the right name:", "panoramix", map.get(ServiceInfo.Fields.Instance));
+        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+    }
+
+    @Test
+    public void testAddressPreserveCase() {
+        String type = "pano_RAmix.local.";
+
+        Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
+
+        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
+        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
+        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
+        assertEquals("We did not get the right name:", "pano_RAmix", map.get(ServiceInfo.Fields.Instance));
+        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+    }
+
+    @Test
+    public void testNameWithUnderscore() {
+        String type = "pano_ramix.local.";
+
+        Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
+
+        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
+        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
+        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
+        assertEquals("We did not get the right name:", "pano_ramix", map.get(ServiceInfo.Fields.Instance));
         assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
     }
 


### PR DESCRIPTION
Moving here fix from https://github.com/jmdns/jmdns/pull/253

`decodeQualifiedNameMapForType` was not able to parse correctly the A/AAA records because the published type is of the format `android_1234.local.`. This was breaking as the `_qualifiedNameMap` recognized the type as only application name due to the underscore in the instance name. Checking the RFC and browsing I came to the conclusion that A/AAA records can only be formatted as <instance>.<domain>. The fix adds an additional regex to support the A/AAA record type format. This solved the majority of the issues where the A/AAA record where stored in cache with the wrong key and never found.

Big problem I encountered and probably will create an issue here is that one of the behaviors changed, and so the test.

 One of the tests `decode` parses the type `DIST123_7-F07_OC030_05_03941.local.` as a lowercase `application`. This goes in contrast with all other test cases where the case of the type are all preserved and the type was not parsed and falled back to one `application`.
 
 one of the other tests like  `testAddress` instead parses and split`panoramix.local.` into 2 parts: `panoramix` (instance/name) and `local` (domain) maintaining the case. The 2 types have the same structure but the underscore which is an allowed character. 
 
 Open to start a discussion about this, but I clearly see a case where the checks and tests are contrasting.