### PR TITLE
Send Answers to QU queries back to sender's address

### DIFF
--- a/src/main/java/javax/jmdns/impl/SocketListener.java
+++ b/src/main/java/javax/jmdns/impl/SocketListener.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * Listen for multicast packets.
  */
 class SocketListener extends Thread {
-    static Logger           logger = LoggerFactory.getLogger(SocketListener.class);
+    static Logger logger = LoggerFactory.getLogger(SocketListener.class);
 
     /**
      *
@@ -69,10 +69,14 @@ class SocketListener extends Thread {
                             logger.trace("{}.run() JmDNS in:{}", this.getName(), msg.print(true));
                         }
                         if (msg.isQuery()) {
-                            if (packet.getPort() != DNSConstants.MDNS_PORT) {
+                            // When we have a QUERY, unique means that QU is true and we should respond to the sender directly
+                            if (msg.getQuestions().stream().anyMatch(DNSEntry::isUnique)) {
                                 this._jmDNSImpl.handleQuery(msg, packet.getAddress(), packet.getPort());
+                            } else if (packet.getPort() != DNSConstants.MDNS_PORT) {
+                                this._jmDNSImpl.handleQuery(msg, packet.getAddress(), packet.getPort());
+                            } else {
+                                this._jmDNSImpl.handleQuery(msg, this._jmDNSImpl.getGroup(), DNSConstants.MDNS_PORT);
                             }
-                            this._jmDNSImpl.handleQuery(msg, this._jmDNSImpl.getGroup(), DNSConstants.MDNS_PORT);
                         } else {
                             this._jmDNSImpl.handleResponse(msg);
                         }

--- a/src/main/java/javax/jmdns/impl/tasks/Responder.java
+++ b/src/main/java/javax/jmdns/impl/tasks/Responder.java
@@ -136,9 +136,7 @@ public class Responder extends DNSTask {
                     logger.debug("{}.run() JmDNS responding", this.getName());
 
                     DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA, !_unicast, _in.getSenderUDPPayload());
-                    if (_unicast) {
-                        out.setDestination(new InetSocketAddress(_addr, _port));
-                    }
+                    out.setDestination(new InetSocketAddress(_addr, _port));
                     out.setId(_in.getId());
                     for (DNSQuestion question : questions) {
                         if (question != null) {


### PR DESCRIPTION
While setting up a printer discovery with jmdns, I found that QU queries are not sent back to the sender's ip address , but back to the broadcast address.

Fixes #153 
Fixes #221 

