### PR TITLE
Do not Pattern match lowerCased ServiceType not to get IndexOutOfBoun…

### DIFF
--- a/src/main/java/javax/jmdns/impl/ServiceTypeDecoder.java
+++ b/src/main/java/javax/jmdns/impl/ServiceTypeDecoder.java
@@ -8,7 +8,7 @@ import static javax.jmdns.ServiceInfo.Fields;
 
 class ServiceTypeDecoder {
 
-    private static final Pattern SUBTYPE_PATTERN = Pattern.compile("^((.*)\\._)?_?(.*)\\._sub\\._([^.]*)\\._([^.]*)\\.(.*)\\.?$");
+    private static final Pattern SUBTYPE_PATTERN = Pattern.compile("^((.*)\\._)?_?(.*)\\._sub\\._([^.]*)\\._([^.]*)\\.(.*)\\.?$", Pattern.CASE_INSENSITIVE);
     private static final Pattern PATTERN = Pattern.compile("^((.*)?\\._)?([^.]*)\\._([^.]*)\\.(.*)\\.?$");
 
     private static final Pattern TYPE_A_PATTERN = Pattern.compile("^([^.]*)\\.(.*)\\.?$");
@@ -43,7 +43,7 @@ class ServiceTypeDecoder {
             domain = casePreservedType.substring(index);
             application = "";
         } else {
-            Matcher subType = SUBTYPE_PATTERN.matcher(aType);
+            Matcher subType = SUBTYPE_PATTERN.matcher(casePreservedType);
             if (subType.matches()) {
                 name = originalCase(casePreservedType, subType, 2);
                 subtype = originalCase(casePreservedType, subType, 3);
@@ -51,14 +51,14 @@ class ServiceTypeDecoder {
                 protocol = originalCase(casePreservedType, subType, 5);
                 domain = originalCase(casePreservedType, subType, 6);
             } else {
-                Matcher normalMatcher = PATTERN.matcher(aType);
+                Matcher normalMatcher = PATTERN.matcher(casePreservedType);
                 if (normalMatcher.matches()) {
                     name = originalCase(casePreservedType, normalMatcher, 2);
                     application = originalCase(casePreservedType, normalMatcher, 3);
                     protocol = originalCase(casePreservedType, normalMatcher, 4);
                     domain = originalCase(casePreservedType, normalMatcher, 5);
                 } else {
-                    Matcher aTypeMatcher = TYPE_A_PATTERN.matcher(aType);
+                    Matcher aTypeMatcher = TYPE_A_PATTERN.matcher(casePreservedType);
                     if (aTypeMatcher.matches()) {
                         name = originalCase(casePreservedType, aTypeMatcher, 1);
                         domain = originalCase(casePreservedType, aTypeMatcher, 2);

--- a/src/test/java/javax/jmdns/impl/ServiceTypeDecoderTest.java
+++ b/src/test/java/javax/jmdns/impl/ServiceTypeDecoderTest.java
@@ -253,6 +253,19 @@ public class ServiceTypeDecoderTest {
     }
 
     @Test
+    public void testNameWithSpecialChar() {
+        String type = "panoramİx.local.";
+
+        Map<ServiceInfo.Fields, String> map = ServiceTypeDecoderr.decodeQualifiedNameMapForType(type);
+
+        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
+        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
+        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
+        assertEquals("We did not get the right name:", "panoramİx", map.get(ServiceInfo.Fields.Instance));
+        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+    }
+
+    @Test
     public void testCasePreserving() {
         String type = "My New Itunes Service._Home-Sharing._TCP.Panoramix.local.";
 
@@ -262,6 +275,19 @@ public class ServiceTypeDecoderTest {
         assertEquals("We did not get the right protocol:", "TCP", map.get(ServiceInfo.Fields.Protocol));
         assertEquals("We did not get the right application:", "Home-Sharing", map.get(ServiceInfo.Fields.Application));
         assertEquals("We did not get the right name:", "My New Itunes Service", map.get(ServiceInfo.Fields.Instance));
+        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+    }
+
+    @Test
+    public void testCasePreservingSpecialChar() {
+        String type = "aBcİ._Home-Sharing._TCP.Panoramix.local.";
+
+        Map<ServiceInfo.Fields, String> map = ServiceTypeDecoderr.decodeQualifiedNameMapForType(type);
+
+        assertEquals("We did not get the right domain:", "Panoramix.local", map.get(ServiceInfo.Fields.Domain));
+        assertEquals("We did not get the right protocol:", "TCP", map.get(ServiceInfo.Fields.Protocol));
+        assertEquals("We did not get the right application:", "Home-Sharing", map.get(ServiceInfo.Fields.Application));
+        assertEquals("We did not get the right name:", "aBcİ", map.get(ServiceInfo.Fields.Instance));
         assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
     }
 


### PR DESCRIPTION
Do not Pattern match lowerCased ServiceType not to get IndexOutOfBoundsException while trying extracting casePreservedType matched groups containing special characters.

Lower casing type is only valid for "arpa" types mdns records, where we compare texts "in-addr.arpa" or "ip6.arpa"

For other types we do not need to work on lowerCased type so we can directly substring params based on casePreservedType Matched groups for given type

fixes([246](https://github.com/jmdns/jmdns/issues/246))