### PR TITLE
Fix for OOM and concurrency issues in DNSCache 

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -26,12 +26,14 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/src/main/java/javax/jmdns/impl/util/SimpleLockManager.java
+++ b/src/main/java/javax/jmdns/impl/util/SimpleLockManager.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Object Matrix 2017
+ */
+
+package javax.jmdns.impl.util;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Basic lock manager which uses internal {@link Map} to maintain a list of current locks.
+ */
+public class SimpleLockManager {
+
+    private final ConcurrentHashMap<String, Locked> _locks = new ConcurrentHashMap<>();
+
+    public Locked lock(String lockKey) {
+        try {
+            return tryLock(lockKey, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        } catch (LockFailedException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("resource")
+    public Locked tryLock(String lockKey, long time, TimeUnit timeunit) throws InterruptedException, LockFailedException {
+        Locked newLock = new LockedImpl(lockKey);
+        long timeoutNanos = timeunit.toNanos(time);
+        long startAt = System.nanoTime();
+        while (true) {
+            Locked previous = _locks.putIfAbsent(lockKey, newLock);
+            if (previous == null)
+                return newLock;
+
+            if ((System.nanoTime() - startAt) >= timeoutNanos)
+                throw new LockFailedException();
+
+            Thread.sleep(10);
+        }
+    }
+
+    private class LockedImpl extends Locked {
+
+        private final String id;
+
+        private LockedImpl(String id) {
+            this.id = id;
+        }
+
+        @SuppressWarnings("resource")
+        @Override
+        public void close() {
+            _locks.remove(id);
+        }
+    }
+    
+    public static abstract class Locked implements Closeable {
+        @Override
+        public abstract void close();
+    }
+    
+    public static class LockFailedException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+    }
+}

--- a/src/test/java/javax/jmdns/test/DNSCacheTest.java
+++ b/src/test/java/javax/jmdns/test/DNSCacheTest.java
@@ -50,6 +50,7 @@ public class DNSCacheTest {
         assertEquals("Could not retrieve the value we inserted", entry, cache.getDNSEntry(entry));
         cache.removeDNSEntry(entry);
         assertNull("Could not remove the value we inserted", cache.getDNSEntry(entry));
+        assertEquals(0, cache.size());
 
         List<DNSEntry> values = cache.get(entry.getKey());
         assertTrue("Cache still has entries for the key", values == null || values.isEmpty());


### PR DESCRIPTION
Hi

The changes are two address 2 issues

problems with door bell camera malformed records, see OOM and high CPU caused by door camera #186
concurrency issues in DNSCache
The problem has been reported here DNSCache leak #200
Fix is provided by Remove entries with no records (jmdns#200) #201 and included in 3.5.6.
Diff for the fix https://github.com/jmdns/jmdns/pull/201/files
It seems however that the fix is incomplete and will have other issues

concurrency issue on entryList.isEmpty() method
concurrency issue with record being added whilst entryList is removed at the same time
This change provides more coarse locking to solve above issues.