### PR TITLE
Create less temporary strings

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSEntry.java
+++ b/src/main/java/javax/jmdns/impl/DNSEntry.java
@@ -51,27 +51,29 @@ public abstract class DNSEntry {
         String application = _qualifiedNameMap.get(Fields.Application);
         String instance = _qualifiedNameMap.get(Fields.Instance).toLowerCase();
         _type = buildType(application, protocol, domain);
-        _key = ((instance.length() > 0 ? instance + "." : "") + _type).toLowerCase();
+        _key = (!instance.isEmpty() ? instance + "." + _type : _type).toLowerCase();
     }
 
     private String buildType(String application, String protocol, String domain) {
-        if (application == null) {
-            application = "";
+        StringBuilder type = new StringBuilder();
+
+        if (application != null && !application.isEmpty()) {
+            type.append('_').append(application).append('.');
         }
 
-        if (protocol == null) {
-            protocol = "";
+        if (protocol != null && !protocol.isEmpty()) {
+            type.append('_').append(protocol).append('.');
         }
 
-        if (domain == null) {
-            domain = "";
+        if (domain != null && !domain.isEmpty()) {
+            type.append('_').append(domain).append('.');
         }
 
-        String type = (!application.isEmpty() ? "_" + application + "." : "") + (!protocol.isEmpty() ? "_" + protocol + "." : "") + (!domain.isEmpty() ? domain + "." : "");
-        if (!type.endsWith(".")) {
-            type += ".";
+        if (type.length() == 0) {
+            return ".";
         }
-        return type;
+
+        return type.toString();
     }
 
     /*

--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -311,10 +311,22 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
      */
     @Override
     public String getType() {
-        String domain = this.getDomain();
-        String protocol = this.getProtocol();
+        StringBuilder type = new StringBuilder();
+
         String application = this.getApplication();
-        return (application.length() > 0 ? "_" + application + "." : "") + (protocol.length() > 0 ? "_" + protocol + "." : "") + domain + ".";
+        if (!application.isEmpty()) {
+            type.append('_').append(application).append('.');
+        }
+
+        String protocol = this.getProtocol();
+        if (!protocol.isEmpty()) {
+            type.append('_').append(protocol).append('.');
+        }
+
+        String domain = this.getDomain();
+        type.append(domain).append('.');
+
+        return type.toString();
     }
 
     /**
@@ -323,7 +335,8 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
     @Override
     public String getTypeWithSubtype() {
         String subtype = this.getSubtype();
-        return (subtype.length() > 0 ? "_" + subtype + "._sub." : "") + this.getType();
+
+        return subtype.isEmpty() ? this.getType() : '_' + subtype + "._sub." + this.getType();
     }
 
     /**
@@ -361,14 +374,9 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
      */
     @Override
     public String getQualifiedName() {
-        String domain = this.getDomain();
-        String protocol = this.getProtocol();
-        String application = this.getApplication();
         String instance = this.getName();
-        // String subtype = this.getSubtype();
-        // return (instance.length() > 0 ? instance + "." : "") + (application.length() > 0 ? "_" + application + "." : "") + (protocol.length() > 0 ? "_" + protocol + (subtype.length() > 0 ? ",_" + subtype.toLowerCase() + "." : ".") : "") + domain
-        // + ".";
-        return (instance.length() > 0 ? instance + "." : "") + (application.length() > 0 ? "_" + application + "." : "") + (protocol.length() > 0 ? "_" + protocol + "." : "") + domain + ".";
+
+        return instance.isEmpty() ? this.getType() : instance + '.' + this.getType();
     }
 
     /**


### PR DESCRIPTION
This PR will use a `StringBuilder` in areas where a lot of temporary strings are created.
To lower the object fallout while handling DNS requests. 

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>