### PR TITLE
Bring relief on excessive logging from DNSIncoming() class

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSMessage.java
+++ b/src/main/java/javax/jmdns/impl/DNSMessage.java
@@ -248,31 +248,42 @@ public abstract class DNSMessage {
     /**
      * Debugging.
      */
-    String print() {
+    protected String print() {
         final StringBuilder sb = new StringBuilder(200);
-        sb.append(this.toString());
-        sb.append("\n");
-        for (final DNSQuestion question : _questions) {
-            sb.append("\tquestion:      ");
-            sb.append(question);
-            sb.append("\n");
-        }
-        for (final DNSRecord answer : _answers) {
-            sb.append("\tanswer:        ");
-            sb.append(answer);
-            sb.append("\n");
-        }
-        for (final DNSRecord answer : _authoritativeAnswers) {
-            sb.append("\tauthoritative: ");
-            sb.append(answer);
-            sb.append("\n");
-        }
-        for (DNSRecord answer : _additionals) {
-            sb.append("\tadditional:    ");
-            sb.append(answer);
-            sb.append("\n");
-        }
+        // statistics, print out the number of DNS entries
+        appendStatistics(sb, "questions", _questions);
+        appendStatistics(sb, "answers", _answers);
+        appendStatistics(sb, "authorities", _authoritativeAnswers);
+        appendStatistics(sb, "additionals", _additionals);
+        // list all DNSEntries
+        appendDNSEntries(sb, "questions", _questions);
+        appendDNSEntries(sb, "answers", _answers);
+        appendDNSEntries(sb, "authorities", _authoritativeAnswers);
+        appendDNSEntries(sb, "additionals", _additionals);
         return sb.toString();
+    }
+
+    private <T extends DNSEntry> void appendStatistics(StringBuilder sb, String name, List<T> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return;
+        }
+        sb.append(", ");
+        sb.append(name);
+        sb.append("=");
+        sb.append(entries.size());
+    }
+
+    private <T extends DNSEntry> void appendDNSEntries(StringBuilder sb, String name, List<T> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return;
+        }
+        sb.append("\n");
+        sb.append(name);
+        sb.append(":");
+        for (DNSEntry entry : entries) {
+            sb.append("\n\t");
+            sb.append(entry);
+        }
     }
 
     /**

--- a/src/main/java/javax/jmdns/impl/DNSOutgoing.java
+++ b/src/main/java/javax/jmdns/impl/DNSOutgoing.java
@@ -405,9 +405,9 @@ public final class DNSOutgoing extends DNSMessage {
      * Debugging.
      */
     String print(boolean dump) {
-        final StringBuilder sb = new StringBuilder();
-        sb.append(this.print());
+        final StringBuilder sb = new StringBuilder(this.toString());
         if (dump) {
+            sb.append("\n");
             sb.append(this.print(this.data()));
         }
         return sb.toString();
@@ -432,50 +432,8 @@ public final class DNSOutgoing extends DNSMessage {
                 sb.append(":tc");
             }
         }
-        if (this.getNumberOfQuestions() > 0) {
-            sb.append(", questions=");
-            sb.append(this.getNumberOfQuestions());
-        }
-        if (this.getNumberOfAnswers() > 0) {
-            sb.append(", answers=");
-            sb.append(this.getNumberOfAnswers());
-        }
-        if (this.getNumberOfAuthorities() > 0) {
-            sb.append(", authorities=");
-            sb.append(this.getNumberOfAuthorities());
-        }
-        if (this.getNumberOfAdditionals() > 0) {
-            sb.append(", additionals=");
-            sb.append(this.getNumberOfAdditionals());
-        }
-        if (this.getNumberOfQuestions() > 0) {
-            sb.append("\nquestions:");
-            for (DNSQuestion question : _questions) {
-                sb.append("\n\t");
-                sb.append(question);
-            }
-        }
-        if (this.getNumberOfAnswers() > 0) {
-            sb.append("\nanswers:");
-            for (DNSRecord record : _answers) {
-                sb.append("\n\t");
-                sb.append(record);
-            }
-        }
-        if (this.getNumberOfAuthorities() > 0) {
-            sb.append("\nauthorities:");
-            for (DNSRecord record : _authoritativeAnswers) {
-                sb.append("\n\t");
-                sb.append(record);
-            }
-        }
-        if (this.getNumberOfAdditionals() > 0) {
-            sb.append("\nadditionals:");
-            for (DNSRecord record : _additionals) {
-                sb.append("\n\t");
-                sb.append(record);
-            }
-        }
+
+        sb.append(this.print());
         sb.append("\nnames=");
         sb.append(_names);
         sb.append("]");

--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordClass.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordClass.java
@@ -126,7 +126,7 @@ public enum DNSRecordClass {
         for (DNSRecordClass aClass : DNSRecordClass.values()) {
             if (aClass._index == maskedIndex) return aClass;
         }
-        logger.warn("Could not find record class for index: {}", index);
+        logger.debug("Could not find record class for index: {}", index);
         return CLASS_UNKNOWN;
     }
 

--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
@@ -301,7 +301,7 @@ public enum DNSRecordType {
         for (DNSRecordType aType : DNSRecordType.values()) {
             if (aType._index == index) return aType;
         }
-        logger.warn("Could not find record type for index: {}", index);
+        logger.debug("Could not find record type for index: {}", index);
         return TYPE_IGNORE;
     }
 

--- a/src/test/java/javax/jmdns/test/DNSRecordTest.java
+++ b/src/test/java/javax/jmdns/test/DNSRecordTest.java
@@ -95,7 +95,7 @@ public class DNSRecordTest {
         Whitebox.setInternalState(dnsIncoming, "_messageInputStream", stream);
         PowerMock.replayAll();
 
-        DNSRecord record = Whitebox.invokeMethod(dnsIncoming, "readAnswer", null);
+        DNSRecord record = Whitebox.invokeMethod(dnsIncoming, "readAnswer");
         Assert.assertNull(record);
         PowerMock.verifyAll();
 


### PR DESCRIPTION
This PR is intended to fix the issue #282 

- _WARNING_ level log changed to  _DEBUG_ level in `DNSRecordClass.classForIndex()`
- _WARNING_ level log changed to  _DEBUG_ level in `DNSRecordType.typeForIndex()`
- Removed `InetAddress` parameter from `DNSIncoming.readAnswer()` to get unified usage of `_packet` field
- `DNSMessage` dump changed from _WARNING_ level to _DEBUG_ level. 
- Call `DNSIncoming.print(boolean dump)` only if debug level logging is enabled (further details: [java:S2629](https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-2629/)).
- Removed duplicate printouts of DNS entries from `DNSIncoming.print(boolean dump)`. Listing of _questions_, _answers_, _additionals_, etc. moved from `DNSIncoming.toString()` method to the `DNSMessage.print()` method of the base class.
- `DNSMessage.print()` format of the printout has been changed to what was originally in `DNSIncoming` and `DNSOutgoing`