### PR TITLE
Fix superfluous null check in DNSRecord

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -571,7 +571,7 @@ public abstract class DNSRecord extends DNSEntry {
         protected void toString(final StringBuilder sb) {
             super.toString(sb);
             sb.append(" alias: '")
-                .append(_alias != null ? _alias : "null")
+                .append(_alias)
                 .append('\'');
         }
 


### PR DESCRIPTION
Fix #194 
- Remove null check before calling StringBuilder.append() method.
https://github.com/jmdns/jmdns/blob/3499b05b21377c9f7db9de6cd5422d90c69c78c7/src/main/java/javax/jmdns/impl/DNSRecord.java#L570