### PR TITLE
Fix DNSRecordTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,15 +73,9 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-module-junit4</artifactId>
-			<version>2.0.7</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-easymock</artifactId>
-			<version>2.0.7</version>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>5.2.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/javax/jmdns/impl/DNSIncoming.java
+++ b/src/main/java/javax/jmdns/impl/DNSIncoming.java
@@ -306,7 +306,7 @@ public final class DNSIncoming extends DNSMessage {
         return DNSQuestion.newQuestion(domain, recordType, recordClass, unique);
     }
 
-    private DNSRecord readAnswer() {
+    DNSRecord readAnswer() {
         String domain = _messageInputStream.readName();
         int recordTypeIndex = _messageInputStream.readUnsignedShort();
         int recordClassIndex = _messageInputStream.readUnsignedShort();


### PR DESCRIPTION
Fixed failing DNSRecordTest.

- [x] Switched from PowerMock to Mockito as Mockito can handle mocking the `clone()` method that PowerMock no longer can in later JDK's.
- [x]  Switched visibility of `readAnswer()` from `private` to `package protected` to allow testing.
- [x] Moved the test to the correct package so it can properly access package protected.

cc @janossch