### PR TITLE
Fix #162: DNSRecord better address equality check

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -333,10 +333,7 @@ public abstract class DNSRecord extends DNSEntry {
                     return false;
                 }
                 Address address = (Address) other;
-                if ((this.getAddress() == null) && (address.getAddress() != null)) {
-                    return false;
-                }
-                return this.getAddress().equals(address.getAddress());
+                return Objects.equals(this.getAddress(), address.getAddress());
             } catch (Exception e) {
                 logger1.info("Failed to compare addresses of DNSRecords", e);
                 return false;


### PR DESCRIPTION
Fix #162: DNSRecord better address equality check

`Object.equals()` handles NULLS on both sides