### PR TITLE
Fix #194: DNSRecord sb.append already handles "null"

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -571,7 +571,7 @@ public abstract class DNSRecord extends DNSEntry {
         protected void toString(final StringBuilder sb) {
             super.toString(sb);
             sb.append(" alias: '")
-                .append(_alias != null ? _alias : "null")
+                .append(_alias)
                 .append('\'');
         }
 


### PR DESCRIPTION
Fix #194: DNSRecord sb.append already handles "null"

@janossch this was the smallest possible PR for this ticket