### PR TITLE
Code cleanup in javax.jmdns.impl.constants package

### DIFF
--- a/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
@@ -11,56 +11,48 @@ package javax.jmdns.impl.constants;
  */
 public final class DNSConstants {
     // http://www.iana.org/assignments/dns-parameters
-
-    // changed to final class - jeffs
-    public static final String MDNS_GROUP                     = System.getProperty("net.mdns.ipv4", "224.0.0.251");
-    public static final String MDNS_GROUP_IPV6                = System.getProperty("net.mdns.ipv6", "FF02::FB");
-    public static final int    MDNS_PORT                      = Integer.getInteger("net.mdns.port", 5353);
-    public static final int    DNS_PORT                       = 53;
-    public static final int    DNS_TTL                        = Integer.getInteger("net.dns.ttl", 60 * 60);                   // default one hour TTL
-    // public static final int DNS_TTL = 120 * 60; // two hour TTL (draft-cheshire-dnsext-multicastdns.txt ch 13)
-
-    public static final int    MAX_MSG_TYPICAL                = 1460;
-    public static final int    MAX_MSG_ABSOLUTE               = 8972;
-
-    public static final int    FLAGS_QR_MASK                  = 0x8000;                                                       // Query response mask
-    public static final int    FLAGS_QR_QUERY                 = 0x0000;                                                       // Query
-    public static final int    FLAGS_QR_RESPONSE              = 0x8000;                                                       // Response
-
-    public static final int    FLAGS_OPCODE                   = 0x7800;                                                       // Operation code
-    public static final int    FLAGS_AA                       = 0x0400;                                                       // Authorative answer
-    public static final int    FLAGS_TC                       = 0x0200;                                                       // Truncated
-    public static final int    FLAGS_RD                       = 0x0100;                                                       // Recursion desired
-    public static final int    FLAGS_RA                       = 0x8000;                                                       // Recursion available
-
-    public static final int    FLAGS_Z                        = 0x0040;                                                       // Zero
-    public static final int    FLAGS_AD                       = 0x0020;                                                       // Authentic data
-    public static final int    FLAGS_CD                       = 0x0010;                                                       // Checking disabled
-    public static final int    FLAGS_RCODE                    = 0x000F;                                                       // Response code
+    public static final String MDNS_GROUP = System.getProperty("net.mdns.ipv4", "224.0.0.251");
+    public static final String MDNS_GROUP_IPV6 = System.getProperty("net.mdns.ipv6", "FF02::FB");
+    public static final int MDNS_PORT = Integer.getInteger("net.mdns.port", 5353);
+    public static final int DNS_PORT = 53;
+    public static final int DNS_TTL = Integer.getInteger("net.dns.ttl", 60 * 60); // default one hour TTL
+    public static final int MAX_MSG_TYPICAL = 1460;
+    public static final int MAX_MSG_ABSOLUTE = 8972;
+    public static final int FLAGS_QR_MASK = 0x8000; // Query response mask
+    public static final int FLAGS_QR_QUERY = 0x0000; // Query
+    public static final int FLAGS_QR_RESPONSE = 0x8000; // Response
+    public static final int FLAGS_OPCODE = 0x7800; // Operation code
+    public static final int FLAGS_AA = 0x0400; // Authoritative answer
+    public static final int FLAGS_TC = 0x0200; // Truncated
+    public static final int FLAGS_RD = 0x0100; // Recursion desired
+    public static final int FLAGS_RA = 0x8000; // Recursion available
+    public static final int FLAGS_Z = 0x0040; // Zero
+    public static final int FLAGS_AD = 0x0020; // Authentic data
+    public static final int FLAGS_CD = 0x0010;  // Checking disabled
+    public static final int FLAGS_RCODE = 0x000F; // Response code
 
     // Time Intervals for various functions
+    public static final int SHARED_QUERY_TIME = 20; // milliseconds before send shared query
+    public static final int QUERY_WAIT_INTERVAL = 225; // milliseconds between query loops.
+    public static final int PROBE_WAIT_INTERVAL = 250; // milliseconds between probe loops.
+    public static final int RESPONSE_MIN_WAIT_INTERVAL = 20; // minimal wait interval for response.
+    public static final int RESPONSE_MAX_WAIT_INTERVAL = 115; // maximal wait interval for response
+    public static final int PROBE_CONFLICT_INTERVAL = 1000; // milliseconds to wait after conflict.
+    public static final int PROBE_THROTTLE_COUNT = 10; // After x tries go 1 time a sec. on probes.
+    public static final int PROBE_THROTTLE_COUNT_INTERVAL = 5000; // We only increment the throttle count, if the previous increment is inside this interval.
+    public static final int ANNOUNCE_WAIT_INTERVAL = 1000; // milliseconds between Announce loops.
+    public static final int RECORD_REAPER_INTERVAL = 10000; // milliseconds between cache cleanups.
+    public static final int RECORD_EXPIRY_DELAY = 1; // This is 1s delay used in ttl and therefore in seconds
+    public static final int KNOWN_ANSWER_TTL = 120;
+    public static final int ANNOUNCED_RENEWAL_TTL_INTERVAL = DNS_TTL * 500; // 50% of the TTL in milliseconds
+    public static final int FLUSH_RECORD_OLDER_THAN_1_SECOND = 1; // rfc6762, section 10.2 Flush outdated cache (older than 1 second)
+    public static final int STALE_REFRESH_INCREMENT = 5;
+    public static final int STALE_REFRESH_STARTING_PERCENTAGE = 80;
+    public static final long CLOSE_TIMEOUT = ANNOUNCE_WAIT_INTERVAL * 5L;
+    public static final long SERVICE_INFO_TIMEOUT = ANNOUNCE_WAIT_INTERVAL * 6L;
+    public static final int NETWORK_CHECK_INTERVAL = 10 * 1000; // 10 seconds
 
-    public static final int    SHARED_QUERY_TIME              = 20;                                                           // milliseconds before send shared query
-    public static final int    QUERY_WAIT_INTERVAL            = 225;                                                          // milliseconds between query loops.
-    public static final int    PROBE_WAIT_INTERVAL            = 250;                                                          // milliseconds between probe loops.
-    public static final int    RESPONSE_MIN_WAIT_INTERVAL     = 20;                                                           // minimal wait interval for response.
-    public static final int    RESPONSE_MAX_WAIT_INTERVAL     = 115;                                                          // maximal wait interval for response
-    public static final int    PROBE_CONFLICT_INTERVAL        = 1000;                                                         // milliseconds to wait after conflict.
-    public static final int    PROBE_THROTTLE_COUNT           = 10;                                                           // After x tries go 1 time a sec. on probes.
-    public static final int    PROBE_THROTTLE_COUNT_INTERVAL  = 5000;                                                         // We only increment the throttle count, if the previous increment is inside this interval.
-    public static final int    ANNOUNCE_WAIT_INTERVAL         = 1000;                                                         // milliseconds between Announce loops.
-    public static final int    RECORD_REAPER_INTERVAL         = 10000;                                                        // milliseconds between cache cleanups.
-    public static final int    RECORD_EXPIRY_DELAY            = 1;                                                            // This is 1s delay used in ttl and therefore in seconds
-    public static final int    KNOWN_ANSWER_TTL               = 120;
-    public static final int    ANNOUNCED_RENEWAL_TTL_INTERVAL = DNS_TTL * 500;                                                // 50% of the TTL in milliseconds
-    public static final int    FLUSH_RECORD_OLDER_THAN_1_SECOND  = 1;                                                         // rfc6762, section 10.2 Flush outdated cache (older than 1 second)
-
-    public static final int    STALE_REFRESH_INCREMENT           = 5;
-    public static final int    STALE_REFRESH_STARTING_PERCENTAGE = 80;
-
-    public static final long   CLOSE_TIMEOUT                  = ANNOUNCE_WAIT_INTERVAL * 5L;
-    public static final long   SERVICE_INFO_TIMEOUT           = ANNOUNCE_WAIT_INTERVAL * 6L;
-
-    public static final int    NETWORK_CHECK_INTERVAL         = 10 * 1000;                                                    // 10 secondes
-
+    private DNSConstants() {
+        // hide implicit public constructor
+    }
 }

--- a/src/main/java/javax/jmdns/impl/constants/DNSLabel.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSLabel.java
@@ -29,16 +29,14 @@ public enum DNSLabel {
     /**
      * DNS label types are encoded on the first 2 bits
      */
-    static final int     LABEL_MASK     = 0xC0;
-    static final int     LABEL_NOT_MASK = 0x3F;
-
-    private final String _externalName;
-
-    private final int    _index;
+    static final int LABEL_MASK = 0xC0;
+    static final int LABEL_NOT_MASK = 0x3F;
+    private final String externalName;
+    private final int indexValue;
 
     DNSLabel(String name, int index) {
-        _externalName = name;
-        _index = index;
+        externalName = name;
+        indexValue = index;
     }
 
     /**
@@ -47,7 +45,7 @@ public enum DNSLabel {
      * @return String
      */
     public String externalName() {
-        return _externalName;
+        return externalName;
     }
 
     /**
@@ -56,7 +54,7 @@ public enum DNSLabel {
      * @return String
      */
     public int indexValue() {
-        return _index;
+        return indexValue;
     }
 
     /**
@@ -65,8 +63,8 @@ public enum DNSLabel {
      */
     public static DNSLabel labelForByte(int index) {
         int maskedIndex = index & LABEL_MASK;
-        for (DNSLabel aLabel : DNSLabel.values()) {
-            if (aLabel._index == maskedIndex) return aLabel;
+        for (DNSLabel label : DNSLabel.values()) {
+            if (label.indexValue == maskedIndex) return label;
         }
         return Unknown;
     }

--- a/src/main/java/javax/jmdns/impl/constants/DNSOperationCode.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSOperationCode.java
@@ -37,24 +37,24 @@ public enum DNSOperationCode {
     /**
      * DNS RCode types are encoded on the last 4 bits
      */
-    static final int     OpCode_MASK = 0x7800;
+    static final int OpCode_MASK = 0x7800;
 
-    private final String _externalName;
+    private final String externalName;
 
-    private final int    _index;
+    private final int indexValue;
 
     DNSOperationCode(String name, int index) {
-        _externalName = name;
-        _index = index;
+        externalName = name;
+        indexValue = index;
     }
 
     /**
      * Return the string representation of this type
-     * 
+     *
      * @return String
      */
     public String externalName() {
-        return _externalName;
+        return externalName;
     }
 
     /**
@@ -63,7 +63,7 @@ public enum DNSOperationCode {
      * @return String
      */
     public int indexValue() {
-        return _index;
+        return indexValue;
     }
 
     /**
@@ -72,8 +72,8 @@ public enum DNSOperationCode {
      */
     public static DNSOperationCode operationCodeForFlags(int flags) {
         int maskedIndex = (flags & OpCode_MASK) >> 11;
-        for (DNSOperationCode aCode : DNSOperationCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
+        for (DNSOperationCode operationCode : DNSOperationCode.values()) {
+            if (operationCode.indexValue == maskedIndex) return operationCode;
         }
         return Unassigned;
     }

--- a/src/main/java/javax/jmdns/impl/constants/DNSOptionCode.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSOptionCode.java
@@ -31,22 +31,22 @@ public enum DNSOptionCode {
      */
     Owner("Owner", 4);
 
-    private final String _externalName;
+    private final String externalName;
 
-    private final int    _index;
+    private final int indexValue;
 
     DNSOptionCode(String name, int index) {
-        _externalName = name;
-        _index = index;
+        externalName = name;
+        indexValue = index;
     }
 
     /**
      * Return the string representation of this type
-     * 
+     *
      * @return String
      */
     public String externalName() {
-        return _externalName;
+        return externalName;
     }
 
     /**
@@ -55,16 +55,16 @@ public enum DNSOptionCode {
      * @return String
      */
     public int indexValue() {
-        return _index;
+        return indexValue;
     }
 
     /**
-     * @param optioncode the option code
+     * @param code the option code
      * @return label
      */
-    public static DNSOptionCode resultCodeForFlags(int optioncode) {
-        for (DNSOptionCode aCode : DNSOptionCode.values()) {
-            if (aCode._index == optioncode) return aCode;
+    public static DNSOptionCode resultCodeForFlags(int code) {
+        for (DNSOptionCode optionCode : DNSOptionCode.values()) {
+            if (optionCode.indexValue == code) return optionCode;
         }
         return Unknown;
     }

--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordClass.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordClass.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  */
 public enum DNSRecordClass {
     /**
-     *
+     * Unknown record class
      */
     CLASS_UNKNOWN("?", 0),
     /**
@@ -41,37 +41,31 @@ public enum DNSRecordClass {
      */
     CLASS_ANY("any", 255);
 
-    private static final Logger       logger       = LoggerFactory.getLogger(DNSRecordClass.class);
+    private static final Logger logger = LoggerFactory.getLogger(DNSRecordClass.class);
 
     /**
      * Multicast DNS uses the bottom 15 bits to identify the record class...<br/>
      * Except for pseudo records like OPT.
      */
-    public static final int     CLASS_MASK   = 0x7FFF;
+    public static final int CLASS_MASK = 0x7FFF;
 
     /**
      * For answers the top bit indicates that all other cached records are now invalid.<br/>
      * For questions, it indicates that we should send a unicast response.
      */
-    public static final int     CLASS_UNIQUE = 0x8000;
+    public static final int CLASS_UNIQUE = 0x8000;
 
-    /**
-     *
-     */
-    public static final boolean UNIQUE       = true;
+    public static final boolean UNIQUE = true;
 
-    /**
-     *
-     */
-    public static final boolean NOT_UNIQUE   = false;
+    public static final boolean NOT_UNIQUE = false;
 
-    private final String        _externalName;
+    private final String externalName;
 
-    private final int           _index;
+    private final int indexValue;
 
     DNSRecordClass(String name, int index) {
-        _externalName = name;
-        _index = index;
+        externalName = name;
+        indexValue = index;
     }
 
     /**
@@ -80,16 +74,16 @@ public enum DNSRecordClass {
      * @return String
      */
     public String externalName() {
-        return _externalName;
+        return externalName;
     }
 
     /**
      * Return the numeric value of this type
-     * 
+     *
      * @return String
      */
     public int indexValue() {
-        return _index;
+        return indexValue;
     }
 
     /**
@@ -108,9 +102,9 @@ public enum DNSRecordClass {
      */
     public static DNSRecordClass classForName(String name) {
         if (name != null) {
-            String aName = name.toLowerCase();
-            for (DNSRecordClass aClass : DNSRecordClass.values()) {
-                if (aClass._externalName.equals(aName)) return aClass;
+            String lowerCaseName = name.toLowerCase();
+            for (DNSRecordClass recordClass : DNSRecordClass.values()) {
+                if (recordClass.externalName.equals(lowerCaseName)) return recordClass;
             }
         }
         logger.warn("Could not find record class for name: {}", name);
@@ -123,8 +117,8 @@ public enum DNSRecordClass {
      */
     public static DNSRecordClass classForIndex(int index) {
         int maskedIndex = index & CLASS_MASK;
-        for (DNSRecordClass aClass : DNSRecordClass.values()) {
-            if (aClass._index == maskedIndex) return aClass;
+        for (DNSRecordClass recordClass : DNSRecordClass.values()) {
+            if (recordClass.indexValue == maskedIndex) return recordClass;
         }
         logger.debug("Could not find record class for index: {}", index);
         return CLASS_UNKNOWN;

--- a/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSRecordType.java
@@ -251,13 +251,13 @@ public enum DNSRecordType {
 
     private static final Logger logger = LoggerFactory.getLogger(DNSRecordType.class);
 
-    private final String  _externalName;
+    private final String externalName;
 
-    private final int     _index;
+    private final int indexValue;
 
     DNSRecordType(String name, int index) {
-        _externalName = name;
-        _index = index;
+        externalName = name;
+        indexValue = index;
     }
 
     /**
@@ -266,7 +266,7 @@ public enum DNSRecordType {
      * @return String
      */
     public String externalName() {
-        return _externalName;
+        return externalName;
     }
 
     /**
@@ -275,7 +275,7 @@ public enum DNSRecordType {
      * @return String
      */
     public int indexValue() {
-        return _index;
+        return indexValue;
     }
 
     /**
@@ -284,9 +284,9 @@ public enum DNSRecordType {
      */
     public static DNSRecordType typeForName(String name) {
         if (name != null) {
-            String aName = name.toLowerCase();
-            for (DNSRecordType aType : DNSRecordType.values()) {
-                if (aType._externalName.equals(aName)) return aType;
+            String lowerCaseName = name.toLowerCase();
+            for (DNSRecordType recordType : DNSRecordType.values()) {
+                if (recordType.externalName.equals(lowerCaseName)) return recordType;
             }
         }
         logger.warn("Could not find record type for name: {}", name);
@@ -298,8 +298,8 @@ public enum DNSRecordType {
      * @return type for name
      */
     public static DNSRecordType typeForIndex(int index) {
-        for (DNSRecordType aType : DNSRecordType.values()) {
-            if (aType._index == index) return aType;
+        for (DNSRecordType recordType : DNSRecordType.values()) {
+            if (recordType.indexValue == index) return recordType;
         }
         logger.debug("Could not find record type for index: {}", index);
         return TYPE_IGNORE;

--- a/src/main/java/javax/jmdns/impl/constants/DNSResultCode.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSResultCode.java
@@ -88,19 +88,19 @@ public enum DNSResultCode {
     /**
      * DNS Result Code types are encoded on the last 4 bits
      */
-    final static int     RCode_MASK         = 0x0F;
+    static final int RCode_MASK = 0x0F;
     /**
      * DNS Extended Result Code types are encoded on the first 8 bits
      */
-    final static int     ExtendedRCode_MASK = 0xFF;
+    static final int ExtendedRCode_MASK = 0xFF;
 
-    private final String _externalName;
+    private final String externalName;
 
-    private final int    _index;
+    private final int indexValue;
 
     DNSResultCode(String name, int index) {
-        _externalName = name;
-        _index = index;
+        externalName = name;
+        indexValue = index;
     }
 
     /**
@@ -109,7 +109,7 @@ public enum DNSResultCode {
      * @return String
      */
     public String externalName() {
-        return _externalName;
+        return externalName;
     }
 
     /**
@@ -118,7 +118,7 @@ public enum DNSResultCode {
      * @return String
      */
     public int indexValue() {
-        return _index;
+        return indexValue;
     }
 
     /**
@@ -127,16 +127,16 @@ public enum DNSResultCode {
      */
     public static DNSResultCode resultCodeForFlags(int flags) {
         int maskedIndex = flags & RCode_MASK;
-        for (DNSResultCode aCode : DNSResultCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
+        for (DNSResultCode resultCode : DNSResultCode.values()) {
+            if (resultCode.indexValue == maskedIndex) return resultCode;
         }
         return Unknown;
     }
 
     public static DNSResultCode resultCodeForFlags(int flags, int extendedRCode) {
         int maskedIndex = ((extendedRCode >> 28) & ExtendedRCode_MASK) | (flags & RCode_MASK);
-        for (DNSResultCode aCode : DNSResultCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
+        for (DNSResultCode resultCode : DNSResultCode.values()) {
+            if (resultCode.indexValue == maskedIndex) return resultCode;
         }
         return Unknown;
     }

--- a/src/main/java/javax/jmdns/impl/constants/DNSState.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSState.java
@@ -10,74 +10,35 @@ package javax.jmdns.impl.constants;
  * @author Werner Randelshofer, Rick Blair, Pierre Frisch
  */
 public enum DNSState {
-
-    /**
-     *
-     */
     PROBING_1("probing 1", StateClass.probing),
-    /**
-    *
-    */
     PROBING_2("probing 2", StateClass.probing),
-    /**
-    *
-    */
     PROBING_3("probing 3", StateClass.probing),
-    /**
-    *
-    */
     ANNOUNCING_1("announcing 1", StateClass.announcing),
-    /**
-    *
-    */
     ANNOUNCING_2("announcing 2", StateClass.announcing),
-    /**
-    *
-    */
     ANNOUNCED("announced", StateClass.announced),
-    /**
-    *
-    */
     CANCELING_1("canceling 1", StateClass.canceling),
-    /**
-    *
-    */
     CANCELING_2("canceling 2", StateClass.canceling),
-    /**
-    *
-    */
     CANCELING_3("canceling 3", StateClass.canceling),
-    /**
-    *
-    */
     CANCELED("canceled", StateClass.canceled),
-    /**
-     *
-     */
     CLOSING("closing", StateClass.closing),
-    /**
-     *
-     */
     CLOSED("closed", StateClass.closed);
 
     private enum StateClass {
         probing, announcing, announced, canceling, canceled, closing, closed
     }
 
-    // private static Logger logger = LoggerFactory.getLogger(DNSState.class);
+    private final String name;
 
-    private final String     _name;
-
-    private final StateClass _state;
+    private final StateClass state;
 
     DNSState(String name, StateClass state) {
-        _name = name;
-        _state = state;
+        this.name = name;
+        this.state = state;
     }
 
     @Override
     public final String toString() {
-        return _name;
+        return name;
     }
 
     /**
@@ -152,7 +113,7 @@ public enum DNSState {
      * @return <code>true</code> if probing state, <code>false</code> otherwise
      */
     public final boolean isProbing() {
-        return _state == StateClass.probing;
+        return state == StateClass.probing;
     }
 
     /**
@@ -161,7 +122,7 @@ public enum DNSState {
      * @return <code>true</code> if announcing state, <code>false</code> otherwise
      */
     public final boolean isAnnouncing() {
-        return _state == StateClass.announcing;
+        return state == StateClass.announcing;
     }
 
     /**
@@ -170,7 +131,7 @@ public enum DNSState {
      * @return <code>true</code> if announced state, <code>false</code> otherwise
      */
     public final boolean isAnnounced() {
-        return _state == StateClass.announced;
+        return state == StateClass.announced;
     }
 
     /**
@@ -179,7 +140,7 @@ public enum DNSState {
      * @return <code>true</code> if canceling state, <code>false</code> otherwise
      */
     public final boolean isCanceling() {
-        return _state == StateClass.canceling;
+        return state == StateClass.canceling;
     }
 
     /**
@@ -188,7 +149,7 @@ public enum DNSState {
      * @return <code>true</code> if canceled state, <code>false</code> otherwise
      */
     public final boolean isCanceled() {
-        return _state == StateClass.canceled;
+        return state == StateClass.canceled;
     }
 
     /**
@@ -197,7 +158,7 @@ public enum DNSState {
      * @return <code>true</code> if closing state, <code>false</code> otherwise
      */
     public final boolean isClosing() {
-        return _state == StateClass.closing;
+        return state == StateClass.closing;
     }
 
     /**
@@ -206,7 +167,7 @@ public enum DNSState {
      * @return <code>true</code> if closed state, <code>false</code> otherwise
      */
     public final boolean isClosed() {
-        return _state == StateClass.closed;
+        return state == StateClass.closed;
     }
 
 }


### PR DESCRIPTION
- Whitespaces removed from field declarations
- Removed empty comments
- Fixed several typos in comments
- [java:S116](https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-116) Renamed local and field variables. Removed leading `_` and `a`. 