### PR TITLE
Code cleanup in packages under javax.jmdns.impl.tasks.

### DIFF
--- a/src/main/java/javax/jmdns/impl/tasks/DNSTask.java
+++ b/src/main/java/javax/jmdns/impl/tasks/DNSTask.java
@@ -14,38 +14,37 @@ import javax.jmdns.impl.constants.DNSConstants;
 
 /**
  * This is the root class for all task scheduled by the timer in JmDNS.
- * 
+ *
  * @author Pierre Frisch
  */
 public abstract class DNSTask extends TimerTask {
 
-    private final JmDNSImpl _jmDNSImpl;
-    
+    private final JmDNSImpl jmDNS;
+
     protected DNSTask(JmDNSImpl jmDNSImpl) {
         super();
-        this._jmDNSImpl = jmDNSImpl;
+        jmDNS = jmDNSImpl;
     }
 
     /**
      * Return the DNS associated with this task.
-     * 
+     *
      * @return associated DNS
      */
     public JmDNSImpl getDns() {
-        return _jmDNSImpl;
+        return jmDNS;
     }
 
     /**
      * Start this task.
-     * 
-     * @param timer
-     *            task timer.
+     *
+     * @param timer task timer.
      */
     public abstract void start(Timer timer);
 
     /**
      * Return this task name.
-     * 
+     *
      * @return task name
      */
     public abstract String getName();
@@ -61,13 +60,11 @@ public abstract class DNSTask extends TimerTask {
 
     /**
      * Add a question to the message.
-     * 
-     * @param out
-     *            outgoing message
-     * @param rec
-     *            DNS question
+     *
+     * @param out outgoing message
+     * @param rec DNS question
      * @return outgoing message for the next question
-     * @exception IOException if any IO error occurs
+     * @throws IOException if any IO error occurs
      */
     public DNSOutgoing addQuestion(DNSOutgoing out, DNSQuestion rec) throws IOException {
         DNSOutgoing newOut = out;
@@ -88,7 +85,7 @@ public abstract class DNSTask extends TimerTask {
 
         newOut.setFlags(flags | DNSConstants.FLAGS_TC);
         newOut.setId(id);
-        this._jmDNSImpl.send(newOut);
+        jmDNS.send(newOut);
 
         newOut = new DNSOutgoing(flags, multicast, maxUDPPayload);
         return newOut;
@@ -96,15 +93,12 @@ public abstract class DNSTask extends TimerTask {
 
     /**
      * Add an answer if it is not suppressed.
-     * 
-     * @param out
-     *            outgoing message
-     * @param in
-     *            incoming request
-     * @param rec
-     *            DNS record answer
+     *
+     * @param out outgoing message
+     * @param in  incoming request
+     * @param rec DNS record answer
      * @return outgoing message for the next answer
-     * @exception IOException if any IO error occurs
+     * @throws IOException if any IO error occurs
      */
     public DNSOutgoing addAnswer(DNSOutgoing out, DNSIncoming in, DNSRecord rec) throws IOException {
         DNSOutgoing newOut = out;
@@ -119,14 +113,12 @@ public abstract class DNSTask extends TimerTask {
 
     /**
      * Add an answer to the message.
-     * 
-     * @param out
-     *            outgoing message
-     * @param rec
-     *            DNS record answer
+     *
+     * @param out outgoing message
+     * @param rec DNS record answer
      * @param now the current time
      * @return outgoing message for the next answer
-     * @exception IOException if any IO error occurs
+     * @throws IOException if any IO error occurs
      */
     public DNSOutgoing addAnswer(DNSOutgoing out, DNSRecord rec, long now) throws IOException {
         DNSOutgoing newOut = out;
@@ -141,13 +133,11 @@ public abstract class DNSTask extends TimerTask {
 
     /**
      * Add an authoritative answer to the message.
-     * 
-     * @param out
-     *            outgoing message
-     * @param rec
-     *            DNS record answer
+     *
+     * @param out outgoing message
+     * @param rec DNS record answer
      * @return outgoing message for the next answer
-     * @exception IOException if any IO error occurs
+     * @throws IOException if any IO error occurs
      */
     public DNSOutgoing addAuthoritativeAnswer(DNSOutgoing out, DNSRecord rec) throws IOException {
         DNSOutgoing newOut = out;
@@ -162,15 +152,12 @@ public abstract class DNSTask extends TimerTask {
 
     /**
      * Adds an answer to the record. Omit if there is no room.
-     * 
-     * @param out
-     *            outgoing message
-     * @param in
-     *            incoming request
-     * @param rec
-     *            DNS record answer
+     *
+     * @param out outgoing message
+     * @param in  incoming request
+     * @param rec DNS record answer
      * @return outgoing message for the next answer
-     * @exception IOException if any IO error occurs
+     * @throws IOException if any IO error occurs
      */
     public DNSOutgoing addAdditionalAnswer(DNSOutgoing out, DNSIncoming in, DNSRecord rec) throws IOException {
         DNSOutgoing newOut = out;

--- a/src/main/java/javax/jmdns/impl/tasks/Responder.java
+++ b/src/main/java/javax/jmdns/impl/tasks/Responder.java
@@ -9,6 +9,7 @@ import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Timer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,30 +24,18 @@ import javax.jmdns.impl.constants.DNSConstants;
  * The Responder sends a single answer for the specified service infos and for the host name.
  */
 public class Responder extends DNSTask {
-    private static final Logger             logger = LoggerFactory.getLogger(Responder.class);
-
-    /**
-     *
-     */
-    private final DNSIncoming _in;
-
-    /**
-     * The incoming address and port.
-     */
-    private final InetAddress _addr;
-    private final int         _port;
-
-    /**
-     *
-     */
-    private final boolean     _unicast;
+    private static final Logger logger = LoggerFactory.getLogger(Responder.class);
+    private final DNSIncoming dnsIncoming;
+    private final InetAddress inetAddress;
+    private final int port;
+    private final boolean unicast;
 
     public Responder(JmDNSImpl jmDNSImpl, DNSIncoming in, InetAddress addr, int port) {
         super(jmDNSImpl);
-        this._in = in;
-        this._addr = addr;
-        this._port = port;
-        this._unicast = (port != DNSConstants.MDNS_PORT);
+        this.dnsIncoming = in;
+        this.inetAddress = addr;
+        this.port = port;
+        this.unicast = (port != DNSConstants.MDNS_PORT);
     }
 
     /*
@@ -64,7 +53,7 @@ public class Responder extends DNSTask {
      */
     @Override
     public String toString() {
-        return super.toString() + " incoming: " + _in;
+        return super.toString() + " incoming: " + dnsIncoming;
     }
 
     /*
@@ -81,14 +70,14 @@ public class Responder extends DNSTask {
         // We respond after 20-120 ms if the query is truncated.
 
         boolean iAmTheOnlyOne = true;
-        for (DNSQuestion question : _in.getQuestions()) {
+        for (DNSQuestion question : dnsIncoming.getQuestions()) {
             logger.trace("{}.start() question={}", this.getName(), question);
             iAmTheOnlyOne = question.iAmTheOnlyOne(this.getDns());
             if (!iAmTheOnlyOne) {
                 break;
             }
         }
-        int delay = (iAmTheOnlyOne && !_in.isTruncated()) ? 0 : DNSConstants.RESPONSE_MIN_WAIT_INTERVAL + JmDNSImpl.getRandom().nextInt(DNSConstants.RESPONSE_MAX_WAIT_INTERVAL - DNSConstants.RESPONSE_MIN_WAIT_INTERVAL + 1) - _in.elapseSinceArrival();
+        int delay = (iAmTheOnlyOne && !dnsIncoming.isTruncated()) ? 0 : DNSConstants.RESPONSE_MIN_WAIT_INTERVAL + JmDNSImpl.getRandom().nextInt(DNSConstants.RESPONSE_MAX_WAIT_INTERVAL - DNSConstants.RESPONSE_MIN_WAIT_INTERVAL + 1) - dnsIncoming.elapseSinceArrival();
         if (delay < 0) {
             delay = 0;
         }
@@ -101,7 +90,7 @@ public class Responder extends DNSTask {
 
     @Override
     public void run() {
-        this.getDns().respondToQuery(_in);
+        this.getDns().respondToQuery(dnsIncoming);
 
         // We use these sets to prevent duplicate records
         Set<DNSQuestion> questions = new HashSet<>();
@@ -110,12 +99,11 @@ public class Responder extends DNSTask {
         if (this.getDns().isAnnounced()) {
             try {
                 // Answer questions
-                for (DNSQuestion question : _in.getQuestions()) {
+                for (DNSQuestion question : dnsIncoming.getQuestions()) {
                     logger.debug("{}.run() JmDNS responding to: {}", this.getName(), question);
 
                     // for unicast responses the question must be included
-                    if (_unicast) {
-                        // out.addQuestion(q);
+                    if (unicast) {
                         questions.add(question);
                     }
 
@@ -124,7 +112,7 @@ public class Responder extends DNSTask {
 
                 // remove known answers, if the TTL is at least half of the correct value. (See Draft Cheshire chapter 7.1.).
                 long now = System.currentTimeMillis();
-                for (DNSRecord knownAnswer : _in.getAnswers()) {
+                for (DNSRecord knownAnswer : dnsIncoming.getAnswers()) {
                     if (knownAnswer.isStale(now)) {
                         answers.remove(knownAnswer);
                         logger.debug("{} - JmDNS Responder Known Answer Removed", this.getName());
@@ -135,9 +123,9 @@ public class Responder extends DNSTask {
                 if (!answers.isEmpty()) {
                     logger.debug("{}.run() JmDNS responding", this.getName());
 
-                    DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA, !_unicast, _in.getSenderUDPPayload());
-                    out.setDestination(new InetSocketAddress(_addr, _port));
-                    out.setId(_in.getId());
+                    DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA, !unicast, dnsIncoming.getSenderUDPPayload());
+                    out.setDestination(new InetSocketAddress(inetAddress, port));
+                    out.setId(dnsIncoming.getId());
                     for (DNSQuestion question : questions) {
                         if (question != null) {
                             out = this.addQuestion(out, question);
@@ -145,15 +133,14 @@ public class Responder extends DNSTask {
                     }
                     for (DNSRecord answer : answers) {
                         if (answer != null) {
-                            out = this.addAnswer(out, _in, answer);
+                            out = this.addAnswer(out, dnsIncoming, answer);
 
                         }
                     }
                     if (!out.isEmpty()) this.getDns().send(out);
                 }
-                // this.cancel();
             } catch (Throwable e) {
-                logger.warn("{}run() exception ", this.getName(), e);
+                logger.warn("{}.run() exception ", this.getName(), e);
                 this.getDns().close();
             }
         }

--- a/src/main/java/javax/jmdns/impl/tasks/resolver/DNSResolverTask.java
+++ b/src/main/java/javax/jmdns/impl/tasks/resolver/DNSResolverTask.java
@@ -3,6 +3,7 @@ package javax.jmdns.impl.tasks.resolver;
 
 import java.io.IOException;
 import java.util.Timer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +14,7 @@ import javax.jmdns.impl.tasks.DNSTask;
 
 /**
  * This is the root class for all resolver tasks.
- * 
+ *
  * @author Pierre Frisch
  */
 public abstract class DNSResolverTask extends DNSTask {
@@ -22,12 +23,12 @@ public abstract class DNSResolverTask extends DNSTask {
     /**
      * Counts the number of queries being sent.
      */
-    protected int         _count = 0;
+    protected int count = 0;
 
     /**
-     * @param jmDNSImpl
+     * @param jmDNSImpl the JmDNS instance which belongs to this resolver task
      */
-    public DNSResolverTask(JmDNSImpl jmDNSImpl) {
+    protected DNSResolverTask(JmDNSImpl jmDNSImpl) {
         super(jmDNSImpl);
     }
 
@@ -37,7 +38,7 @@ public abstract class DNSResolverTask extends DNSTask {
      */
     @Override
     public String toString() {
-        return super.toString() + " count: " + _count;
+        return super.toString() + " count: " + count;
     }
 
     /*
@@ -61,8 +62,8 @@ public abstract class DNSResolverTask extends DNSTask {
             if (this.getDns().isCanceling() || this.getDns().isCanceled()) {
                 this.cancel();
             } else {
-                if (_count++ < 3) {
-                    logger.debug("{}.run() JmDNS {}",this.getName(), this.description());
+                if (count++ < 3) {
+                    logger.debug("{}.run() JmDNS {}", this.getName(), this.description());
 
                     DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_QUERY);
                     out = this.addQuestions(out);
@@ -86,28 +87,26 @@ public abstract class DNSResolverTask extends DNSTask {
     /**
      * Overridden by subclasses to add questions to the message.<br/>
      * <b>Note:</b> Because of message size limitation the returned message may be different from the message parameter.
-     * 
-     * @param out
-     *            outgoing message
+     *
+     * @param out outgoing message
      * @return the outgoing message.
-     * @exception IOException
+     * @throws IOException
      */
     protected abstract DNSOutgoing addQuestions(DNSOutgoing out) throws IOException;
 
     /**
      * Overridden by subclasses to add questions to the message.<br/>
      * <b>Note:</b> Because of message size limitation the returned message may be different from the message parameter.
-     * 
-     * @param out
-     *            outgoing message
+     *
+     * @param out outgoing message
      * @return the outgoing message.
-     * @exception IOException
+     * @throws IOException
      */
     protected abstract DNSOutgoing addAnswers(DNSOutgoing out) throws IOException;
 
     /**
      * Returns a description of the resolver for debugging
-     * 
+     *
      * @return resolver description
      */
     protected abstract String description();

--- a/src/main/java/javax/jmdns/impl/tasks/resolver/ServiceInfoResolver.java
+++ b/src/main/java/javax/jmdns/impl/tasks/resolver/ServiceInfoResolver.java
@@ -22,13 +22,13 @@ import javax.jmdns.impl.constants.DNSRecordType;
  */
 public class ServiceInfoResolver extends DNSResolverTask {
 
-    private final ServiceInfoImpl _info;
+    private final ServiceInfoImpl serviceInfo;
 
     public ServiceInfoResolver(JmDNSImpl jmDNSImpl, ServiceInfoImpl info) {
         super(jmDNSImpl);
-        this._info = info;
-        info.setDns(this.getDns());
-        this.getDns().addListener(info, DNSQuestion.newQuestion(info.getQualifiedName(), DNSRecordType.TYPE_ANY, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+        serviceInfo = info;
+        serviceInfo.setDns(getDns());
+        getDns().addListener(info, DNSQuestion.newQuestion(serviceInfo.getQualifiedName(), DNSRecordType.TYPE_ANY, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
     }
 
     /*
@@ -48,8 +48,8 @@ public class ServiceInfoResolver extends DNSResolverTask {
     public boolean cancel() {
         // We should not forget to remove the listener
         boolean result = super.cancel();
-        if (!_info.isPersistent()) {
-            this.getDns().removeListener(_info);
+        if (!serviceInfo.isPersistent()) {
+            this.getDns().removeListener(serviceInfo);
         }
         return result;
     }
@@ -61,15 +61,15 @@ public class ServiceInfoResolver extends DNSResolverTask {
     @Override
     protected DNSOutgoing addAnswers(DNSOutgoing out) throws IOException {
         DNSOutgoing newOut = out;
-        if (!_info.hasData()) {
+        if (!serviceInfo.hasData()) {
             long now = System.currentTimeMillis();
-            newOut = this.addAnswer(newOut, (DNSRecord) this.getDns().getCache().getDNSEntry(_info.getQualifiedName(), DNSRecordType.TYPE_SRV, DNSRecordClass.CLASS_IN), now);
-            newOut = this.addAnswer(newOut, (DNSRecord) this.getDns().getCache().getDNSEntry(_info.getQualifiedName(), DNSRecordType.TYPE_TXT, DNSRecordClass.CLASS_IN), now);
-            if (!_info.getServer().isEmpty()) {
-                for (DNSEntry addressEntry : this.getDns().getCache().getDNSEntryList(_info.getServer(), DNSRecordType.TYPE_A, DNSRecordClass.CLASS_IN)) {
+            newOut = this.addAnswer(newOut, (DNSRecord) this.getDns().getCache().getDNSEntry(serviceInfo.getQualifiedName(), DNSRecordType.TYPE_SRV, DNSRecordClass.CLASS_IN), now);
+            newOut = this.addAnswer(newOut, (DNSRecord) this.getDns().getCache().getDNSEntry(serviceInfo.getQualifiedName(), DNSRecordType.TYPE_TXT, DNSRecordClass.CLASS_IN), now);
+            if (!serviceInfo.getServer().isEmpty()) {
+                for (DNSEntry addressEntry : this.getDns().getCache().getDNSEntryList(serviceInfo.getServer(), DNSRecordType.TYPE_A, DNSRecordClass.CLASS_IN)) {
                     newOut = this.addAnswer(newOut, (DNSRecord) addressEntry, now);
                 }
-                for (DNSEntry addressEntry : this.getDns().getCache().getDNSEntryList(_info.getServer(), DNSRecordType.TYPE_AAAA, DNSRecordClass.CLASS_IN)) {
+                for (DNSEntry addressEntry : this.getDns().getCache().getDNSEntryList(serviceInfo.getServer(), DNSRecordType.TYPE_AAAA, DNSRecordClass.CLASS_IN)) {
                     newOut = this.addAnswer(newOut, (DNSRecord) addressEntry, now);
                 }
             }
@@ -84,12 +84,12 @@ public class ServiceInfoResolver extends DNSResolverTask {
     @Override
     protected DNSOutgoing addQuestions(DNSOutgoing out) throws IOException {
         DNSOutgoing newOut = out;
-        if (!_info.hasData()) {
-            newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_info.getQualifiedName(), DNSRecordType.TYPE_SRV, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
-            newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_info.getQualifiedName(), DNSRecordType.TYPE_TXT, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
-            if (!_info.getServer().isEmpty()) {
-                newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_info.getServer(), DNSRecordType.TYPE_A, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
-                newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_info.getServer(), DNSRecordType.TYPE_AAAA, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+        if (!serviceInfo.hasData()) {
+            newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(serviceInfo.getQualifiedName(), DNSRecordType.TYPE_SRV, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+            newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(serviceInfo.getQualifiedName(), DNSRecordType.TYPE_TXT, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+            if (!serviceInfo.getServer().isEmpty()) {
+                newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(serviceInfo.getServer(), DNSRecordType.TYPE_A, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+                newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(serviceInfo.getServer(), DNSRecordType.TYPE_AAAA, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
             }
         }
         return newOut;
@@ -101,7 +101,7 @@ public class ServiceInfoResolver extends DNSResolverTask {
      */
     @Override
     protected String description() {
-        return "querying service info: " + (_info != null ? _info.getQualifiedName() : "null");
+        return "querying service info: " + (serviceInfo != null ? serviceInfo.getQualifiedName() : "null");
     }
 
 }

--- a/src/main/java/javax/jmdns/impl/tasks/resolver/ServiceResolver.java
+++ b/src/main/java/javax/jmdns/impl/tasks/resolver/ServiceResolver.java
@@ -22,11 +22,11 @@ import javax.jmdns.impl.constants.DNSRecordType;
  */
 public class ServiceResolver extends DNSResolverTask {
 
-    private final String _type;
+    private final String type;
 
     public ServiceResolver(JmDNSImpl jmDNSImpl, String type) {
         super(jmDNSImpl);
-        this._type = type;
+        this.type = type;
     }
 
     /*
@@ -59,8 +59,7 @@ public class ServiceResolver extends DNSResolverTask {
     @Override
     protected DNSOutgoing addQuestions(DNSOutgoing out) throws IOException {
         DNSOutgoing newOut = out;
-        newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_type, DNSRecordType.TYPE_PTR, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
-        // newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_type, DNSRecordType.TYPE_SRV, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+        newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(type, DNSRecordType.TYPE_PTR, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
         return newOut;
     }
 

--- a/src/main/java/javax/jmdns/impl/tasks/state/DNSStateTask.java
+++ b/src/main/java/javax/jmdns/impl/tasks/state/DNSStateTask.java
@@ -4,6 +4,7 @@ package javax.jmdns.impl.tasks.state;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,61 +18,61 @@ import javax.jmdns.impl.constants.DNSState;
 import javax.jmdns.impl.tasks.DNSTask;
 
 /**
- * This is the root class for all state tasks. These tasks work with objects that implements the {@link javax.jmdns.impl.DNSStatefulObject} interface and therefore participate in the state machine.
- * 
+ * This is the root class for all state tasks. These tasks work with objects that implements the
+ * {@link javax.jmdns.impl.DNSStatefulObject} interface and therefore participate in the state machine.
+ *
  * @author Pierre Frisch
  */
 public abstract class DNSStateTask extends DNSTask {
-    static Logger      logger     = LoggerFactory.getLogger(DNSStateTask.class);
+    private static final Logger logger = LoggerFactory.getLogger(DNSStateTask.class);
 
     /**
      * By setting a 0 ttl we effectively expire the record.
      */
-    private final int  _ttl;
+    private final int ttl;
 
-    private static int _defaultTTL = DNSConstants.DNS_TTL;
+    private static int defaultTTL = DNSConstants.DNS_TTL;
 
     /**
      * The state of the task.
      */
-    private DNSState   _taskState  = null;
+    private DNSState taskState = null;
 
     public abstract String getTaskDescription();
 
     public static int defaultTTL() {
-        return _defaultTTL;
+        return defaultTTL;
     }
 
     /**
      * For testing only do not use in production.
-     * 
+     *
      * @param value
      */
     public static void setDefaultTTL(int value) {
-        _defaultTTL = value;
+        defaultTTL = value;
     }
 
     /**
      * @param jmDNSImpl
      * @param ttl
      */
-    public DNSStateTask(JmDNSImpl jmDNSImpl, int ttl) {
+    DNSStateTask(JmDNSImpl jmDNSImpl, int ttl) {
         super(jmDNSImpl);
-        _ttl = ttl;
+        this.ttl = ttl;
     }
 
     /**
      * @return the ttl
      */
     public int getTTL() {
-        return _ttl;
+        return ttl;
     }
 
     /**
      * Associate the DNS host and the service infos with this task if not already associated and in the same state.
-     * 
-     * @param state
-     *            target state
+     *
+     * @param state target state
      */
     protected void associate(DNSState state) {
         synchronized (this.getDns()) {
@@ -120,7 +121,7 @@ public abstract class DNSStateTask extends DNSTask {
 
                 synchronized (info) {
                     if (info.isAssociatedWithTask(this, this.getTaskState())) {
-                        logger.debug("{}.run() JmDNS {} {}",this.getName(), this.getTaskDescription(), info.getQualifiedName());
+                        logger.debug("{}.run() JmDNS {} {}", this.getName(), this.getTaskDescription(), info.getQualifiedName());
                         stateObjects.add(info);
                         out = this.buildOutgoingForInfo(info, out);
                     }
@@ -174,15 +175,14 @@ public abstract class DNSStateTask extends DNSTask {
      * @return the taskState
      */
     protected DNSState getTaskState() {
-        return this._taskState;
+        return this.taskState;
     }
 
     /**
-     * @param taskState
-     *            the taskState to set
+     * @param taskState the taskState to set
      */
     protected void setTaskState(DNSState taskState) {
-        this._taskState = taskState;
+        this.taskState = taskState;
     }
 
 }


### PR DESCRIPTION
- Remove unnecessary whitespaces
- fix several typos in comments, 
- rename local and field variables (remove leading "_")
- use `@throws` instead of `@exception` in comments
- change the `public` constructor of the `public abstract DNSResolverTask` class to `protected`