### PR TITLE
TEST ONLY - Improving tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,15 +61,21 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 			<version>2.0.7</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.10.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.easymock</groupId>
-			<artifactId>easymock</artifactId>
-			<version>3.3.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.10.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.5.6</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -116,10 +122,7 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
-				<configuration>
-					<skipTests>true</skipTests>
-				</configuration>
+				<version>3.5.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -250,21 +253,6 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 	</build>
 
 	<profiles>
-		<profile>
-			<id>test</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.18.1</version>
-						<configuration>
-							<skipTests>false</skipTests>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 		<profile>
 			<id>release-sign-artifacts</id>
 			<activation>

--- a/src/test/java/javax/jmdns/impl/DNSCacheTest.java
+++ b/src/test/java/javax/jmdns/impl/DNSCacheTest.java
@@ -11,57 +11,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.test;
+package javax.jmdns.impl;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 import javax.jmdns.impl.DNSCache;
 import javax.jmdns.impl.DNSEntry;
 import javax.jmdns.impl.DNSRecord;
 import javax.jmdns.impl.constants.DNSRecordClass;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.List;
 
-public class DNSCacheTest {
+import static org.junit.jupiter.api.Assertions.*;
 
-    @Before
-    public void setup() {
-        //
-    }
+class DNSCacheTest {
 
     @Test
-    public void testCacheCreation() {
+    void testCacheCreation() {
         DNSCache cache = new DNSCache();
-        assertNotNull("Could not create a new DNS cache.", cache);
+        assertNotNull(cache, "Could not create a new DNS cache.");
     }
 
     @Test
-    public void testCacheAddEntry() {
+    void testCacheAddEntry() {
         DNSCache cache = new DNSCache();
 
         DNSEntry entry = new DNSRecord.Service("pierre._home-sharing._tcp.local.", DNSRecordClass.CLASS_IN, false, 0, 0, 0, 0, "panoramix.local.");
         cache.addDNSEntry(entry);
-        assertEquals("Could not retrieve the value we inserted", entry, cache.getDNSEntry(entry));
-
+        assertEquals(entry, cache.getDNSEntry(entry), "Could not retrieve the value we inserted");
     }
 
     @Test
-    public void testCacheRemoveEntry() {
+    void testCacheRemoveEntry() {
         DNSCache cache = new DNSCache();
 
         DNSEntry entry = new DNSRecord.Service("pierre._home-sharing._tcp.local.", DNSRecordClass.CLASS_IN, false, 0, 0, 0, 0, "panoramix.local.");
         cache.addDNSEntry(entry);
-        assertEquals("Could not retrieve the value we inserted", entry, cache.getDNSEntry(entry));
+        assertEquals(entry, cache.getDNSEntry(entry), "Could not retrieve the value we inserted");
         cache.removeDNSEntry(entry);
-        assertNull("Could not remove the value we inserted", cache.getDNSEntry(entry));
+        assertNull(cache.getDNSEntry(entry), "Could not remove the value we inserted");
         assertEquals(0, cache.size());
 
         List<DNSEntry> values = cache.get(entry.getKey());
-        assertTrue("Cache still has entries for the key", values == null || values.isEmpty());
-        assertNull("Cache contains key with no entries", values);
+        assertTrue(values == null || values.isEmpty(), "Cache still has entries for the key");
+        assertNull(values, "Cache contains key with no entries");
     }
 
 }

--- a/src/test/java/javax/jmdns/impl/DNSMessageTest.java
+++ b/src/test/java/javax/jmdns/impl/DNSMessageTest.java
@@ -11,32 +11,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.test;
+package javax.jmdns.impl;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.util.Date;
 
-import javax.jmdns.impl.DNSIncoming;
-import javax.jmdns.impl.DNSOutgoing;
-import javax.jmdns.impl.DNSQuestion;
-import javax.jmdns.impl.DNSRecord;
 import javax.jmdns.impl.constants.DNSConstants;
 import javax.jmdns.impl.constants.DNSRecordClass;
 import javax.jmdns.impl.constants.DNSRecordType;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class DNSMessageTest {
+class DNSMessageTest {
 
     private static final byte[] nmap_scan_package = new byte[] { 0x30, (byte) 0x82, 0x00, 0x2f, 0x02, 0x01, 0x00, 0x04, 0x06, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, (byte) 0xa0, (byte) 0x82, 0x00, 0x20, 0x02, 0x04, 0x4c, 0x33, (byte) 0xa7, 0x56, 0x02,
             0x01, 0x00, 0x02, 0x01, 0x00, 0x30, (byte) 0x82, 0x00, 0x10, 0x30, (byte) 0x82, 0x00, 0x0c, 0x06, 0x08, 0x2b, 0x06, 0x01, 0x02, 0x01, 0x01, 0x05, 0x00, 0x05, 0x00 };
 
     @Test
-    public void testIncomingOverflow() {
+    void testIncomingOverflow() {
         try {
             // The DNSIncoming constructor should probably do bounds checking on the following parts of the package: questions, answers, authorities, additionals
             // The package above results in these values
@@ -52,40 +48,40 @@ public class DNSMessageTest {
     }
 
     @Test
-    public void testCreateQuery() throws IOException {
+    void testCreateQuery() throws IOException {
         String serviceName = "_00000000-0b44-f234-48c8-071c565644b3._sub._home-sharing._tcp.local.";
         DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_QUERY);
-        assertNotNull("Could not create the outgoing message", out);
+        assertNotNull(out, "Could not create the outgoing message");
         out.addQuestion(DNSQuestion.newQuestion(serviceName, DNSRecordType.TYPE_ANY, DNSRecordClass.CLASS_IN, true));
         byte[] data = out.data();
-        assertNotNull("Could not encode the outgoing message", data);
+        assertNotNull(data, "Could not encode the outgoing message");
         byte[] expected = new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x25, 0x5f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x2d, 0x30, 0x62, 0x34, 0x34, 0x2d, 0x66, 0x32, 0x33, 0x34, 0x2d, 0x34, 0x38, 0x63, 0x38,
                 0x2d, 0x30, 0x37, 0x31, 0x63, 0x35, 0x36, 0x35, 0x36, 0x34, 0x34, 0x62, 0x33, 0x4, 0x5f, 0x73, 0x75, 0x62, 0xd, 0x5f, 0x68, 0x6f, 0x6d, 0x65, 0x2d, 0x73, 0x68, 0x61, 0x72, 0x69, 0x6e, 0x67, 0x4, 0x5f, 0x74, 0x63, 0x70, 0x5, 0x6c,
                 0x6f, 0x63, 0x61, 0x6c, 0x0, 0x0, (byte) 0xff, 0x0, 0x1 };
         for (int i = 0; i < data.length; i++) {
-            assertEquals("the encoded message is not what is expected at index " + i, expected[i], data[i]);
+            assertEquals(expected[i], data[i], "the encoded message is not what is expected at index " + i);
         }
         DatagramPacket packet = new DatagramPacket(data, 0, data.length);
         DNSIncoming in = new DNSIncoming(packet);
-        assertTrue("Wrong packet type.", in.isQuery());
-        assertEquals("Wrong number of questions.", 1, in.getNumberOfQuestions());
+        assertTrue(in.isQuery(), "Wrong packet type.");
+        assertEquals(1, in.getNumberOfQuestions(), "Wrong number of questions.");
         for (DNSQuestion question : in.getQuestions()) {
-            assertEquals("Wrong question name.", serviceName, question.getName());
+            assertEquals(serviceName, question.getName(), "Wrong question name.");
         }
     }
 
     @Test
-    public void testCreateAnswer() throws IOException {
+    void testCreateAnswer() throws IOException {
         String serviceType = "_home-sharing._tcp.local.";
         String serviceName = "Pierre." + serviceType;
         DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA, false);
-        assertNotNull("Could not create the outgoing message", out);
+        assertNotNull(out, "Could not create the outgoing message");
         out.addQuestion(DNSQuestion.newQuestion(serviceName, DNSRecordType.TYPE_ANY, DNSRecordClass.CLASS_IN, true));
         long now = (new Date()).getTime();
         out.addAnswer(new DNSRecord.Pointer(serviceType, DNSRecordClass.CLASS_IN, true, DNSConstants.DNS_TTL, serviceName), now);
         out.addAuthorativeAnswer(new DNSRecord.Service(serviceType, DNSRecordClass.CLASS_IN, true, DNSConstants.DNS_TTL, 1, 20, 8080, "panoramix.local."));
         byte[] data = out.data();
-        assertNotNull("Could not encode the outgoing message", data);
+        assertNotNull(data, "Could not encode the outgoing message");
         // byte[] expected = new byte[] { 0x0, 0x0, (byte) 0x84, 0x0, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x0, 0x6, 0x50, 0x69, 0x65, 0x72, 0x72, 0x65, 0xd, 0x5f, 0x68, 0x6f, 0x6d, 0x65, 0x2d, 0x73, 0x68, 0x61, 0x72, 0x69, 0x6e, 0x67, 0x4, 0x5f, 0x74,
         // 0x63, 0x70, 0x5, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x0, 0x0, (byte) 0xff, 0x0, 0x1, (byte) 0xc0, 0x13, 0x0, 0xc, 0x0, 0x1, 0x0, 0x0, 0xe, 0xf, 0x0, 0x21, 0x6, 0x50, 0x69, 0x65, 0x72, 0x72, 0x65, 0xd, 0x5f, 0x68, 0x6f, 0x6d, 0x65, 0x2d,
         // 0x73, 0x68, 0x61, 0x72, 0x69, 0x6e, 0x67, 0x4, 0x5f, 0x74, 0x63, 0x70, 0x5, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x0, (byte) 0xc0, 0x13, 0x0, 0x21, 0x0, 0x1, 0x0, 0x0, 0xe, 0xf, 0x0, 0x17, 0x0, 0x1, 0x0, 0x14, 0x1f, (byte) 0x90, 0x9, 0x70,
@@ -96,12 +92,12 @@ public class DNSMessageTest {
         // }
         DatagramPacket packet = new DatagramPacket(data, 0, data.length);
         DNSIncoming in = new DNSIncoming(packet);
-        assertTrue("Wrong packet type.", in.isResponse());
-        assertEquals("Wrong number of questions.", 1, in.getNumberOfQuestions());
-        assertEquals("Wrong number of answers.", 1, in.getNumberOfAnswers());
-        assertEquals("Wrong number of authorities.", 1, in.getNumberOfAuthorities());
+        assertTrue(in.isResponse(), "Wrong packet type.");
+        assertEquals(1, in.getNumberOfQuestions(), "Wrong number of questions.");
+        assertEquals(1, in.getNumberOfAnswers(), "Wrong number of answers.");
+        assertEquals(1, in.getNumberOfAuthorities(), "Wrong number of authorities.");
         for (DNSQuestion question : in.getQuestions()) {
-            assertEquals("Wrong question name.", serviceName, question.getName());
+            assertEquals(serviceName, question.getName(), "Wrong question name.");
         }
     }
 

--- a/src/test/java/javax/jmdns/impl/DNSRecordTest.java
+++ b/src/test/java/javax/jmdns/impl/DNSRecordTest.java
@@ -13,20 +13,21 @@
  */
 package javax.jmdns.impl;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.impl.constants.DNSRecordClass;
 import javax.jmdns.impl.constants.DNSRecordType;
+import javax.jmdns.test.util.ReflectionUtils;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 
-public class DNSRecordTest {
+class DNSRecordTest {
 
     private static final int TTL_IN_SECONDS = 60 * 60; // ONE HOUR
     private static final long ONE_HOUR_IN_MILLIS = 60 * 60 * 1000;
@@ -36,44 +37,44 @@ public class DNSRecordTest {
     private static final long PERCENT_STALE_94 = ONE_HOUR_IN_MILLIS * 94 / 100;
     private static final long PERCENT_STALE_99 = ONE_HOUR_IN_MILLIS * 99 / 100;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Mockito.reset();
     }
 
     @Test
-    public void testStaleDNSRecord() {
-        DNSRecord record = new DNSRecord.Service("test", DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, "test");
+    void testStaleDNSRecord() {
+        DNSRecord dnsRecord = createServiceRecord("test", "test_server");
         long now = System.currentTimeMillis();
 
         // stale threshold is 80% + random offset
-        Assert.assertFalse("Record should not be stale after creation", record.isStaleAndShouldBeRefreshed(now));
-        Assert.assertFalse("79% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_79));
-        Assert.assertTrue("84% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_84));
+        assertFalse(dnsRecord.isStaleAndShouldBeRefreshed(now), "Record should not be stale after creation");
+        assertFalse(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_79), "79% should not be stale");
+        assertTrue(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_84), "84% should be stale");
 
         // stale threshold is 85% + random offset
-        record.incrementRefreshPercentage();
-        Assert.assertFalse("84% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_84));
-        Assert.assertTrue("89% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_89));
+        dnsRecord.incrementRefreshPercentage();
+        assertFalse(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_84), "84% should not be stale");
+        assertTrue(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_89), "89% should be stale");
 
         // stale threshold is 90% + random offset
-        record.incrementRefreshPercentage();
-        Assert.assertFalse("89% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_89));
-        Assert.assertTrue("94% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_94));
+        dnsRecord.incrementRefreshPercentage();
+        assertFalse(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_89), "89% should not be stale");
+        assertTrue(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_94), "94% should be stale");
 
         // stale threshold is 95% + random offset
-        record.incrementRefreshPercentage();
-        Assert.assertFalse("94% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_94));
-        Assert.assertTrue("99% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_99));
+        dnsRecord.incrementRefreshPercentage();
+        assertFalse(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_94), "94% should not be stale");
+        assertTrue(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_99), "99% should be stale");
 
         // stale threshold is 100%
-        record.incrementRefreshPercentage();
-        Assert.assertFalse("99% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_99));
-        Assert.assertTrue("100% should be stale", record.isStaleAndShouldBeRefreshed(now + ONE_HOUR_IN_MILLIS));
+        dnsRecord.incrementRefreshPercentage();
+        assertFalse(dnsRecord.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_99), "99% should not be stale");
+        assertTrue(dnsRecord.isStaleAndShouldBeRefreshed(now + ONE_HOUR_IN_MILLIS), "100% should be stale");
     }
 
     @Test
-    public void testIPv4MappedIPv6Addresses() throws Exception {
+    void testIPv4MappedIPv6Addresses() throws Exception {
         // Mock DNSIncoming.MessageInputStream
         DNSIncoming.MessageInputStream stream = mock(DNSIncoming.MessageInputStream.class);
         when(stream.readName()).thenReturn("test");
@@ -86,42 +87,49 @@ public class DNSRecordTest {
 
         // Mock DNSIncoming and set the stream internally
         DNSIncoming dnsIncoming = mock(DNSIncoming.class);
-        setInternalState(dnsIncoming, "_messageInputStream", stream);
+        ReflectionUtils.setInternalState(dnsIncoming, "_messageInputStream", stream);
 
         // Invoke the method
-        DNSRecord record = doCallRealMethod().when(dnsIncoming).readAnswer();
-        Assert.assertNull(record);
+        DNSRecord dnsRecord = doCallRealMethod().when(dnsIncoming).readAnswer();
+        assertNull(dnsRecord);
     }
 
-    public void setInternalState(Object targetObject, String fieldName, Object value) throws Exception {
-        Field field = targetObject.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);  // Make the field accessible
-        field.set(targetObject, value);  // Set the new value
+
+
+    @Test
+    void testServiceInfoFromDNSRecord() {
+        DNSRecord dnsRecord = createServiceRecord("test._http._tcp.local.", "test_server");
+
+        ServiceInfo serviceInfo = dnsRecord.getServiceInfo(true);
+
+        assertEquals("test", serviceInfo.getName());
+        assertEquals("http", serviceInfo.getApplication());
+        assertEquals("tcp", serviceInfo.getProtocol());
+        assertEquals("local", serviceInfo.getDomain());
+        assertEquals("test_server", serviceInfo.getServer());
     }
 
     @Test
-    public void testServiceInfoFromDNSRecord() {
-        DNSRecord record = new DNSRecord.Service("test._http._tcp.local.", DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, "test_server");
-
-        ServiceInfo serviceInfo = record.getServiceInfo(true);
-
-        Assert.assertEquals("test", serviceInfo.getName());
-        Assert.assertEquals("http", serviceInfo.getApplication());
-        Assert.assertEquals("tcp", serviceInfo.getProtocol());
-        Assert.assertEquals("local", serviceInfo.getDomain());
-        Assert.assertEquals("test_server", serviceInfo.getServer());
-    }
-
-    @Test
-    public void testDNSRecordKey() {
+    void testDNSRecordKey() {
         // test starting with underscore seen on some Android devices
-        DNSRecord record1 = new DNSRecord.Service("_android_123.local.", DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, "test_server");
-        Assert.assertEquals("_android_123.local.", record1.getKey());
+        DNSRecord record1 = createServiceRecord("_android_123.local.", "test_server");
+        assertEquals("_android_123.local.", record1.getKey());
 
-        DNSRecord record2 = new DNSRecord.Service("test._http._tcp.local.", DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, "test_server");
-        Assert.assertEquals("test._http._tcp.local.", record2.getKey());
+        DNSRecord record2 = createServiceRecord("test._http._tcp.local.", "test_server");
+        assertEquals("test._http._tcp.local.", record2.getKey());
 
-        DNSRecord record3 = new DNSRecord.Service("TEST._http._tcp.local.", DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, "test_server");
-        Assert.assertEquals("test._http._tcp.local.", record3.getKey());
+        DNSRecord record3 = createServiceRecord("TEST._http._tcp.local.", "test_server");
+        assertEquals("test._http._tcp.local.", record3.getKey());
+    }
+
+    @Test
+    void testHostInformationEquals() {
+        DNSRecord.HostInformation h1 = new DNSRecord.HostInformation(null, DNSRecordClass.CLASS_IN, true, 0, null, null);
+        DNSRecord.HostInformation h2 = new DNSRecord.HostInformation(null, DNSRecordClass.CLASS_IN, true, 0, null, null);
+        assertEquals(h1, h2);
+    }
+
+    private static DNSRecord.Service createServiceRecord(String name, String server) {
+        return new DNSRecord.Service(name, DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, server);
     }
 }

--- a/src/test/java/javax/jmdns/impl/JmDNSTest.java
+++ b/src/test/java/javax/jmdns/impl/JmDNSTest.java
@@ -13,16 +13,12 @@
  */
 package javax.jmdns.impl;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.MulticastSocket;
-import java.net.NetworkInterface;
-import java.net.UnknownHostException;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,76 +28,63 @@ import javax.jmdns.JmmDNS;
 import javax.jmdns.ServiceEvent;
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceListener;
-import javax.jmdns.ServiceTypeListener;
 import javax.jmdns.impl.constants.DNSConstants;
+import javax.jmdns.test.EventStoringServiceListener;
 
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
-public class JmDNSTest {
+class JmDNSTest {
 
-    @SuppressWarnings("unused")
-    private ServiceTypeListener typeListenerMock;
-    private ServiceListener     serviceListenerMock;
-    private ServiceInfo         service;
+    private ServiceListener serviceListenerMock;
+    private ServiceInfo service;
+    private static final String SERVICE_KEY = "srvname"; // Max 9 chars
+    private static final int MPORT = 8053;
 
-    private final static String serviceKey = "srvname"; // Max 9 chars
-
-    @Before
+    @BeforeEach
     public void setup() {
         String text = "Test hypothetical web server";
-        Map<String, byte[]> properties = new HashMap<String, byte[]>();
-        properties.put(serviceKey, text.getBytes());
+        Map<String, byte[]> properties = new HashMap<>();
+        properties.put(SERVICE_KEY, text.getBytes());
         service = ServiceInfo.create("_html._tcp.local.", "apache-someuniqueid", 80, 0, 0, true, properties);
-        typeListenerMock = createMock(ServiceTypeListener.class);
-        serviceListenerMock = createNiceMock("ServiceListener", ServiceListener.class);
+        serviceListenerMock = mock(ServiceListener.class);
     }
 
     @Test
-    public void testCreate() throws IOException {
-        System.out.println("Unit Test: testCreate()");
-        JmDNS registry = JmDNS.create();
+    void testCreate() throws IOException {
+        JmDNSImpl registry = (JmDNSImpl) JmDNS.create();
+        assertNotNull(registry);
         registry.close();
+        assertTrue(registry.isCanceled()); // should it be canceled after close?
     }
 
     @Test
-    public void testCreateINet() throws IOException {
-        System.out.println("Unit Test: testCreateINet()");
-        JmDNS registry = JmDNS.create(InetAddress.getLocalHost());
-        // assertEquals("We did not register on the local host inet:", InetAddress.getLocalHost(), registry.getInterface());
-        registry.close();
-    }
-
-    @Test
-    public void testRegisterService() throws IOException {
-        System.out.println("Unit Test: testRegisterService()");
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
-            registry.registerService(service);
-
-            ServiceInfo[] services = registry.list(service.getType());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
-            assertEquals(service, services[0]);
-        } finally {
-            if (registry != null) registry.close();
+    void testCreateINet() throws IOException {
+        InetAddress localhost = InetAddress.getLocalHost();
+        try (JmDNS registry = JmDNS.create(localhost)) {
+            assertEquals(localhost, registry.getInetAddress(), "We did not register on the inetAddress of the localhost");
         }
     }
 
     @Test
-    public void testUnregisterService() throws IOException, InterruptedException {
-        System.out.println("Unit Test: testUnregisterService()");
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+    void testRegisterService() throws IOException {
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
 
             ServiceInfo[] services = registry.list(service.getType());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
+            assertEquals(1, services.length, "We should see the service we just registered: ");
+            assertEquals(service, services[0]);
+        }
+    }
+
+    @Test
+    void testUnregisterService() throws IOException, InterruptedException {
+        try (JmDNS registry = JmDNS.create()) {
+            registry.registerService(service);
+
+            ServiceInfo[] services = registry.list(service.getType());
+            assertEquals(1, services.length, "We should see the service we just registered: ");
             assertEquals(service, services[0]);
 
             // now unregister and make sure it's gone
@@ -112,39 +95,27 @@ public class JmDNSTest {
             Thread.sleep(1500);
 
             services = registry.list(service.getType());
-            assertTrue("We should not see the service we just unregistered: ", services == null || services.length == 0);
-        } finally {
-            if (registry != null) registry.close();
+            assertTrue(services == null || services.length == 0, "We should not see the service we just unregistered: ");
         }
     }
 
     @Test
-    public void testRegisterServiceTwice() throws IOException {
-        System.out.println("Unit Test: testRegisterService()");
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+    void testRegisterServiceTwice() throws IOException {
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
-            // This should cause an exception
-            registry.registerService(service);
-            fail("Registering the same service info should fail.");
-        } catch (IllegalStateException exception) {
-            // Expected exception.
-        } finally {
-            if (registry != null) registry.close();
+            assertThrows(IllegalStateException.class,
+                    () -> registry.registerService(service),
+                    "Registering the same service info should fail.");
         }
     }
 
     @Test
-    public void testUnregisterAndReregisterService() throws IOException, InterruptedException {
-        System.out.println("Unit Test: testUnregisterAndReregisterService()");
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+    void testUnregisterAndRegisterService() throws IOException, InterruptedException {
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
 
             ServiceInfo[] services = registry.list(service.getType());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
+            assertEquals(1, services.length, "We should see the service we just registered: ");
             assertEquals(service, services[0]);
 
             // now unregister and make sure it's gone
@@ -155,219 +126,149 @@ public class JmDNSTest {
             Thread.sleep(1500);
 
             services = registry.list(service.getType());
-            assertTrue("We should not see the service we just unregistered: ", services == null || services.length == 0);
+            assertTrue(services == null || services.length == 0, "We should not see the service we just unregistered: ");
 
             registry.registerService(service);
             Thread.sleep(5000);
             services = registry.list(service.getType());
-            assertTrue("We should see the service we just reregistered: ", services != null && services.length > 0);
-        } finally {
-            if (registry != null) registry.close();
+            assertTrue(services != null && services.length > 0, "We should see the service we just registered again: ");
         }
     }
 
     @Test
-    public void testQueryMyService() throws IOException {
-        System.out.println("Unit Test: testQueryMyService()");
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+    void testQueryMyService() throws IOException, InterruptedException {
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
+            Thread.sleep(6000);
             ServiceInfo queriedService = registry.getServiceInfo(service.getType(), service.getName());
             assertEquals(service, queriedService);
-        } finally {
-            if (registry != null) registry.close();
         }
     }
 
     @Test
-    public void testListMyService() throws IOException {
-        System.out.println("Unit Test: testListMyService()");
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+    void testListMyService() throws IOException {
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
             ServiceInfo[] services = registry.list(service.getType());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
+            assertEquals(1, services.length, "We should see the service we just registered: ");
             assertEquals(service, services[0]);
-        } finally {
-            if (registry != null) registry.close();
         }
     }
 
     @Test
-    public void testListMyServiceIPV6() throws IOException {
-        System.out.println("Unit Test: testListMyServiceIPV6()");
-        JmDNS registry = null;
-        try {
-            InetAddress address = InetAddress.getLocalHost();
-            NetworkInterface interfaze = NetworkInterface.getByInetAddress(address);
-            for (Enumeration<InetAddress> iaenum = interfaze.getInetAddresses(); iaenum.hasMoreElements();) {
-                InetAddress interfaceAddress = iaenum.nextElement();
-                if (interfaceAddress instanceof Inet6Address) {
-                    address = interfaceAddress;
-                }
+    void testListMyServiceIPV6() throws IOException {
+        InetAddress address = InetAddress.getLocalHost();
+        NetworkInterface networkInterface = NetworkInterface.getByInetAddress(address);
+        for (Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses(); inetAddresses.hasMoreElements(); ) {
+            InetAddress interfaceAddress = inetAddresses.nextElement();
+            if (interfaceAddress instanceof Inet6Address) {
+                address = interfaceAddress;
             }
-            registry = JmDNS.create(address);
+        }
+        try (JmDNS registry = JmDNS.create(address)) {
             registry.registerService(service);
             ServiceInfo[] services = registry.list(service.getType());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
+            assertEquals(1, services.length, "We should see the service we just registered: ");
             assertEquals(service, services[0]);
-        } finally {
-            if (registry != null) registry.close();
         }
     }
 
     @Test
-    public void testListenForMyService() throws IOException {
-        System.out.println("Unit Test: testListenForMyService()");
-        JmDNS registry = null;
-        try {
-            Capture<ServiceEvent> capServiceAddedEvent = EasyMock.newCapture();
-            Capture<ServiceEvent> capServiceResolvedEvent = EasyMock.newCapture();
-            // Add an expectation that the listener interface will be called once capture the object so I can verify it separately.
-            serviceListenerMock.serviceAdded(capture(capServiceAddedEvent));
-            serviceListenerMock.serviceResolved(capture(capServiceResolvedEvent));
-            EasyMock.replay(serviceListenerMock);
-            // EasyMock.makeThreadSafe(serviceListenerMock, false);
+    void testListenForMyService() throws IOException, InterruptedException {
+        ArgumentCaptor<ServiceEvent> capServiceAddedEvent = ArgumentCaptor.forClass(ServiceEvent.class);
+        ArgumentCaptor<ServiceEvent> capServiceResolvedEvent = ArgumentCaptor.forClass(ServiceEvent.class);
 
-            registry = JmDNS.create();
-
+        try (JmDNS registry = JmDNS.create()) {
             registry.addServiceListener(service.getType(), serviceListenerMock);
-
             registry.registerService(service);
+            Thread.sleep(6000);
 
-            // We get the service added event when we register the service. However the service has not been resolved at this point.
+            verify(serviceListenerMock, atLeastOnce()).serviceAdded(capServiceAddedEvent.capture());
+            verify(serviceListenerMock, atLeastOnce()).serviceResolved(capServiceResolvedEvent.capture());
+            // We get the service added event when we register the service. However, the service has not been resolved at this point.
             // The info associated with the event only has the minimum information i.e. name and type.
-            assertTrue("We did not get the service added event.", capServiceAddedEvent.hasCaptured());
+            assertFalse(capServiceAddedEvent.getAllValues().isEmpty(), "We did not get the service added event.");
             ServiceInfo info = capServiceAddedEvent.getValue().getInfo();
-            assertEquals("We did not get the right name for the added service:", service.getName(), info.getName());
-            assertEquals("We did not get the right type for the added service:", service.getType(), info.getType());
-            assertEquals("We did not get the right fully qualified name for the added service:", service.getQualifiedName(), info.getQualifiedName());
-
-            // assertEquals("We should not get the server for the added service:", "", info.getServer());
-            // assertEquals("We should not get the address for the added service:", null, info.getAddress());
-            // assertEquals("We should not get the HostAddress for the added service:", "", info.getHostAddress());
-            // assertEquals("We should not get the InetAddress for the added service:", null, info.getInetAddress());
-            // assertEquals("We should not get the NiceTextString for the added service:", "", info.getNiceTextString());
-            // assertEquals("We should not get the Priority for the added service:", 0, info.getPriority());
-            // assertFalse("We should not get the PropertyNames for the added service:", info.getPropertyNames().hasMoreElements());
-            // assertEquals("We should not get the TextBytes for the added service:", 0, info.getTextBytes().length);
-            // assertEquals("We should not get the TextString for the added service:", null, info.getTextString());
-            // assertEquals("We should not get the Weight for the added service:", 0, info.getWeight());
-            // assertNotSame("We should not get the URL for the added service:", "", info.getURL());
+            assertEquals(service.getName(), info.getName(), "We did not get the right name for the added service:");
+            assertEquals(service.getType(), info.getType(), "We did not get the right type for the added service:");
+            assertEquals(service.getQualifiedName(), info.getQualifiedName(), "We did not get the right fully qualified name for the added service:");
 
             registry.requestServiceInfo(service.getType(), service.getName());
 
-            assertTrue("We did not get the service resolved event.", capServiceResolvedEvent.hasCaptured());
-            verify(serviceListenerMock);
+            assertFalse(capServiceResolvedEvent.getAllValues().isEmpty(), "We did not get the service resolved event.");
+
             ServiceInfo resolvedInfo = capServiceResolvedEvent.getValue().getInfo();
-            assertEquals("Did not get the expected service info: ", service, resolvedInfo);
-        } finally {
-            if (registry != null) registry.close();
+            assertEquals(service, resolvedInfo, "Did not get the expected service info: ");
         }
     }
 
     @Test
-    public void testListenForMyServiceAndList() throws IOException {
-        System.out.println("Unit Test: testListenForMyServiceAndList()");
-        JmDNS registry = null;
-        try {
-            Capture<ServiceEvent> capServiceAddedEvent = EasyMock.newCapture();
-            Capture<ServiceEvent> capServiceResolvedEvent = EasyMock.newCapture();
-            // Expect the listener to be called once and capture the result
-            serviceListenerMock.serviceAdded(capture(capServiceAddedEvent));
-            serviceListenerMock.serviceResolved(capture(capServiceResolvedEvent));
-            replay(serviceListenerMock);
+    void testListenForMyServiceAndList() throws IOException, InterruptedException {
+        ArgumentCaptor<ServiceEvent> capServiceAddedEvent = ArgumentCaptor.forClass(ServiceEvent.class);
+        ArgumentCaptor<ServiceEvent> capServiceResolvedEvent = ArgumentCaptor.forClass(ServiceEvent.class);
 
-            registry = JmDNS.create();
+        try (JmDNS registry = JmDNS.create()) {
             registry.addServiceListener(service.getType(), serviceListenerMock);
             registry.registerService(service);
+            Thread.sleep(6000);
 
-            // We get the service added event when we register the service. However the service has not been resolved at this point.
+            verify(serviceListenerMock, atLeastOnce()).serviceAdded(capServiceAddedEvent.capture());
+            verify(serviceListenerMock, atLeastOnce()).serviceResolved(capServiceResolvedEvent.capture());
+            // We get the service added event when we register the service. However, the service has not been resolved at this point.
             // The info associated with the event only has the minimum information i.e. name and type.
-            assertTrue("We did not get the service added event.", capServiceAddedEvent.hasCaptured());
-
             ServiceInfo info = capServiceAddedEvent.getValue().getInfo();
-            assertEquals("We did not get the right name for the resolved service:", service.getName(), info.getName());
-            assertEquals("We did not get the right type for the resolved service:", service.getType(), info.getType());
+            assertEquals(service.getName(), info.getName(), "We did not get the right name for the resolved service:");
+            assertEquals(service.getType(), info.getType(), "We did not get the right type for the resolved service:");
 
             // This will force the resolution of the service which in turn will get the listener called with a service resolved event.
             // The info associated with a service resolved event has all the information available.
-            // Which in turn populates the ServiceInfo opbjects returned by JmDNS.list.
+            // Which in turn populates the ServiceInfo objects returned by JmDNS.list.
             ServiceInfo[] services = registry.list(info.getType());
-            assertEquals("We did not get the expected number of services: ", 1, services.length);
-            assertEquals("The service returned was not the one expected", service, services[0]);
+            assertEquals(1, services.length, "We did not get the expected number of services: ");
+            assertEquals(service, services[0], "The service returned was not the one expected");
 
-            assertTrue("We did not get the service resolved event.", capServiceResolvedEvent.hasCaptured());
-            verify(serviceListenerMock);
             ServiceInfo resolvedInfo = capServiceResolvedEvent.getValue().getInfo();
-            assertEquals("Did not get the expected service info: ", service, resolvedInfo);
-        } finally {
-            if (registry != null) registry.close();
+            assertEquals(service, resolvedInfo, "Did not get the expected service info: ");
         }
     }
 
     @Test
-    public void testListenForServiceOnOtherRegistry() throws IOException {
-        System.out.println("Unit Test: testListenForServiceOnOtherRegistry()");
-        JmDNS registry = null;
-        JmDNS newServiceRegistry = null;
-        try {
-            Capture<ServiceEvent> capServiceAddedEvent = EasyMock.newCapture();
-            Capture<ServiceEvent> capServiceResolvedEvent = EasyMock.newCapture();
-            // Expect the listener to be called once and capture the result
-            serviceListenerMock.serviceAdded(capture(capServiceAddedEvent));
-            serviceListenerMock.serviceResolved(capture(capServiceResolvedEvent));
-            replay(serviceListenerMock);
+    void testListenForServiceOnOtherRegistry() throws IOException, InterruptedException {
+        ArgumentCaptor<ServiceEvent> capServiceAddedEvent = ArgumentCaptor.forClass(ServiceEvent.class);
+        ArgumentCaptor<ServiceEvent> capServiceResolvedEvent = ArgumentCaptor.forClass(ServiceEvent.class);
 
-            registry = JmDNS.create();
+        try (JmDNS registry = JmDNS.create();
+             JmDNS newServiceRegistry = JmDNS.create()) {
             registry.addServiceListener(service.getType(), serviceListenerMock);
-            //
-            newServiceRegistry = JmDNS.create();
             newServiceRegistry.registerService(service);
+            Thread.sleep(6000);
 
-            // We get the service added event when we register the service. However the service has not been resolved at this point.
+            verify(serviceListenerMock, atLeastOnce()).serviceAdded(capServiceAddedEvent.capture());
+            verify(serviceListenerMock, atLeastOnce()).serviceResolved(capServiceResolvedEvent.capture());
+            // We get the service added event when we register the service. However, the service has not been resolved at this point.
             // The info associated with the event only has the minimum information i.e. name and type.
-            assertTrue("We did not get the service added event.", capServiceAddedEvent.hasCaptured());
             ServiceInfo info = capServiceAddedEvent.getValue().getInfo();
-            assertEquals("We did not get the right name for the resolved service:", service.getName(), info.getName());
-            assertEquals("We did not get the right type for the resolved service:", service.getType(), info.getType());
-            // We get the service added event when we register the service. However the service has not been resolved at this point.
-            // The info associated with the event only has the minimum information i.e. name and type.
-            assertTrue("We did not get the service resolved event.", capServiceResolvedEvent.hasCaptured());
-            verify(serviceListenerMock);
+            assertEquals(service.getName(), info.getName(), "We did not get the right name for the resolved service:");
+            assertEquals(service.getType(), info.getType(), "We did not get the right type for the resolved service:");
             Object result = capServiceResolvedEvent.getValue().getInfo();
-            assertEquals("Did not get the expected service info: ", service, result);
-        } finally {
-            if (registry != null) registry.close();
-            if (newServiceRegistry != null) newServiceRegistry.close();
+            assertEquals(service, result, "Did not get the expected service info: ");
         }
     }
 
     @Test
-    public void testWaitAndQueryForServiceOnOtherRegistry() throws IOException {
-        System.out.println("Unit Test: testWaitAndQueryForServiceOnOtherRegistry()");
-        JmDNS registry = null;
-        JmDNS newServiceRegistry = null;
-        try {
-            newServiceRegistry = JmDNS.create();
-            registry = JmDNS.create();
-
+    void testWaitAndQueryForServiceOnOtherRegistry() throws Exception {
+        try (JmDNS newServiceRegistry = JmDNS.create(InetAddress.getLocalHost());
+             JmDNS registry = JmDNS.create(InetAddress.getLocalHost())) {
             registry.registerService(service);
-
+            Thread.sleep(6000);
             ServiceInfo fetchedService = newServiceRegistry.getServiceInfo(service.getType(), service.getName());
-
-            assertEquals("Did not get the expected service info: ", service, fetchedService);
-        } finally {
-            if (registry != null) registry.close();
-            if (newServiceRegistry != null) newServiceRegistry.close();
+            assertNotNull(fetchedService, "ServiceInfo is a null reference");
+            assertEquals(service, fetchedService, "Did not get the expected service info: ");
         }
     }
 
     @Test
-    public void testRegisterAndListServiceOnOtherRegistry() throws IOException, InterruptedException {
-        System.out.println("Unit Test: testRegisterAndListServiceOnOtherRegistry()");
+    void testRegisterAndListServiceOnOtherRegistry() throws IOException, InterruptedException {
         JmDNS registry = null;
         JmDNS newServiceRegistry = null;
         try {
@@ -377,20 +278,20 @@ public class JmDNSTest {
             newServiceRegistry = JmDNS.create("Listener");
             Thread.sleep(6000);
             ServiceInfo[] fetchedServices = newServiceRegistry.list(service.getType());
-            assertEquals("Did not get the expected services listed:", 1, fetchedServices.length);
-            assertEquals("Did not get the expected service type:", service.getType(), fetchedServices[0].getType());
-            assertEquals("Did not get the expected service name:", service.getName(), fetchedServices[0].getName());
-            assertEquals("Did not get the expected service fully qualified name:", service.getQualifiedName(), fetchedServices[0].getQualifiedName());
+            assertEquals(1, fetchedServices.length, "Did not get the expected services listed:");
+            assertEquals(service.getType(), fetchedServices[0].getType(), "Did not get the expected service type:");
+            assertEquals(service.getName(), fetchedServices[0].getName(), "Did not get the expected service name:");
+            assertEquals(service.getQualifiedName(), fetchedServices[0].getQualifiedName(), "Did not get the expected service fully qualified name:");
             newServiceRegistry.getServiceInfo(service.getType(), service.getName());
 
-            assertEquals("Did not get the expected service info: ", service, fetchedServices[0]);
+            assertEquals(service, fetchedServices[0], "Did not get the expected service info: ");
             registry.close();
             registry = null;
             // According to the spec the record disappears from the cache 1s after it has been unregistered
             // without sleeping for a while, the service would not be unregistered fully
             Thread.sleep(1500);
             fetchedServices = newServiceRegistry.list(service.getType());
-            assertEquals("The service was not cancelled after the close:", 0, fetchedServices.length);
+            assertEquals(0, fetchedServices.length, "The service was not cancelled after the close:");
         } finally {
             if (registry != null) registry.close();
             if (newServiceRegistry != null) newServiceRegistry.close();
@@ -398,11 +299,8 @@ public class JmDNSTest {
     }
 
     @Test
-    public void testAddServiceListenerTwice() throws IOException {
-        System.out.println("Unit Test: testAddServiceListenerTwice()");
-        JmDNSImpl registry = null;
-        try {
-            registry = (JmDNSImpl) JmDNS.create();
+    void testAddServiceListenerTwice() throws IOException {
+        try (JmDNSImpl registry = (JmDNSImpl) JmDNS.create()) {
             registry.addServiceListener("test", serviceListenerMock);
 
             // we will have 2 listeners, since the collector is implicitly added as well
@@ -410,17 +308,12 @@ public class JmDNSTest {
 
             registry.addServiceListener("test", serviceListenerMock);
             assertEquals(2, registry._serviceListeners.get("test").size());
-        } finally {
-            if (registry != null) registry.close();
         }
     }
 
     @Test
-    public void testRemoveServiceListener() throws IOException {
-        System.out.println("Unit Test: testRemoveServiceListener()");
-        JmDNSImpl registry = null;
-        try {
-            registry = (JmDNSImpl) JmDNS.create();
+    void testRemoveServiceListener() throws IOException {
+        try (JmDNSImpl registry = (JmDNSImpl) JmDNS.create()) {
             registry.addServiceListener("test", serviceListenerMock);
             // we will have 2 listeners, since the collector is implicitly added as well
             assertEquals(2, registry._serviceListeners.get("test").size());
@@ -428,25 +321,23 @@ public class JmDNSTest {
             registry.removeServiceListener("test", serviceListenerMock);
             // the collector is left in place
             assertEquals(1, registry._serviceListeners.get("test").size());
-        } finally {
-            if (registry != null) registry.close();
         }
     }
 
-    public static final class Receive extends Thread {
-        MulticastSocket _socket;
-        DatagramPacket  _in;
+    private static final class Receive extends Thread {
+        MulticastSocket multicastSocket;
+        DatagramPacket datagramPacket;
 
         public Receive(MulticastSocket socket, DatagramPacket in) {
             super("Test Receive Multicast");
-            _socket = socket;
-            _in = in;
+            multicastSocket = socket;
+            datagramPacket = in;
         }
 
         @Override
         public void run() {
             try {
-                _socket.receive(_in);
+                multicastSocket.receive(datagramPacket);
             } catch (IOException exception) {
                 // Ignore
             }
@@ -463,12 +354,8 @@ public class JmDNSTest {
 
     }
 
-    private final static int MPORT = 8053;
-
     @Test
-    @Ignore
-    public void testTwoMulticastPortsAtOnce() throws UnknownHostException, IOException {
-        System.out.println("Unit Test: testTwoMulticastPortsAtOnce()");
+    void testTwoMulticastPortsAtOnce() throws IOException {
         MulticastSocket firstSocket = null;
         MulticastSocket secondSocket = null;
         try {
@@ -481,35 +368,34 @@ public class JmDNSTest {
             firstSocket.joinGroup(someInet);
             secondSocket.joinGroup(someInet);
             //
-            DatagramPacket out = new DatagramPacket(firstMessage.getBytes("UTF-8"), firstMessage.length(), someInet, MPORT);
-            DatagramPacket inFirst = new DatagramPacket(firstMessage.getBytes("UTF-8"), firstMessage.length(), someInet, MPORT);
-            DatagramPacket inSecond = new DatagramPacket(firstMessage.getBytes("UTF-8"), firstMessage.length(), someInet, MPORT);
+            DatagramPacket out = new DatagramPacket(firstMessage.getBytes(StandardCharsets.UTF_8), firstMessage.length(), someInet, MPORT);
+            DatagramPacket inSecond = new DatagramPacket(firstMessage.getBytes(StandardCharsets.UTF_8), firstMessage.length(), someInet, MPORT);
             Receive receiveSecond = new Receive(secondSocket, inSecond);
             receiveSecond.start();
             Receive receiveFirst = new Receive(firstSocket, inSecond);
             receiveFirst.start();
             firstSocket.send(out);
             if (receiveSecond.waitForReceive()) {
-                Assert.fail("We did not receive the data in the second socket");
+                fail("We did not receive the data in the second socket");
             }
-            String fromFirst = new String(inSecond.getData(), "UTF-8");
-            assertEquals("Expected the second socket to recieve the same message the first socket sent", firstMessage, fromFirst);
+            String fromFirst = new String(inSecond.getData(), StandardCharsets.UTF_8);
+            assertEquals(firstMessage, fromFirst, "Expected the second socket to recieve the same message the first socket sent");
             // Make sure the first socket had read its own message
             if (receiveSecond.waitForReceive()) {
-                Assert.fail("We did not receive the data in the first socket");
+                fail("We did not receive the data in the first socket");
             }
             // Reverse the roles
-            out = new DatagramPacket(secondMessage.getBytes("UTF-8"), secondMessage.length(), someInet, MPORT);
-            inFirst = new DatagramPacket(secondMessage.getBytes("UTF-8"), secondMessage.length(), someInet, MPORT);
+            out = new DatagramPacket(secondMessage.getBytes(StandardCharsets.UTF_8), secondMessage.length(), someInet, MPORT);
+            DatagramPacket inFirst = new DatagramPacket(secondMessage.getBytes(StandardCharsets.UTF_8), secondMessage.length(), someInet, MPORT);
             receiveFirst = new Receive(firstSocket, inSecond);
             receiveFirst.start();
 
             secondSocket.send(out);
             if (receiveFirst.waitForReceive()) {
-                Assert.fail("We did not receive the data in the first socket");
+                fail("We did not receive the data in the first socket");
             }
-            String fromSecond = new String(inFirst.getData(), "UTF-8");
-            assertEquals("Expected the first socket to recieve the same message the second socket sent", secondMessage, fromSecond);
+            String fromSecond = new String(inFirst.getData(), StandardCharsets.UTF_8);
+            assertEquals(secondMessage, fromSecond, "Expected the first socket to recieve the same message the second socket sent");
         } finally {
             if (firstSocket != null) firstSocket.close();
             if (secondSocket != null) secondSocket.close();
@@ -517,20 +403,17 @@ public class JmDNSTest {
     }
 
     @Test
-    public void testListMyServiceWithToLowerCase() throws IOException, InterruptedException {
-        System.out.println("Unit Test: testListMyServiceWithToLowerCase()");
+    void testListMyServiceWithToLowerCase() throws IOException, InterruptedException {
         String text = "Test hypothetical web server";
-        Map<String, byte[]> properties = new HashMap<String, byte[]>();
-        properties.put(serviceKey, text.getBytes());
+        Map<String, byte[]> properties = new HashMap<>();
+        properties.put(SERVICE_KEY, text.getBytes());
         service = ServiceInfo.create("_HtmL._TcP.lOcAl.", "apache-someUniqueid", 80, 0, 0, true, properties);
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
 
             // with toLowerCase
             ServiceInfo[] services = registry.list(service.getType().toLowerCase());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
+            assertEquals(1, services.length, "We should see the service we just registered: ");
             assertEquals(service, services[0]);
             // now unregister and make sure it's gone
             registry.unregisterService(services[0]);
@@ -538,27 +421,22 @@ public class JmDNSTest {
             // without sleeping for a while, the service would not be unregistered fully
             Thread.sleep(1500);
             services = registry.list(service.getType().toLowerCase());
-            assertTrue("We should not see the service we just unregistered: ", services == null || services.length == 0);
-        } finally {
-            if (registry != null) registry.close();
+            assertTrue(services == null || services.length == 0, "We should not see the service we just unregistered: ");
         }
     }
 
     @Test
-    public void testListMyServiceWithoutLowerCase() throws IOException, InterruptedException {
-        System.out.println("Unit Test: testListMyServiceWithoutLowerCase()");
+    void testListMyServiceWithoutLowerCase() throws IOException, InterruptedException {
         String text = "Test hypothetical web server";
-        Map<String, byte[]> properties = new HashMap<String, byte[]>();
-        properties.put(serviceKey, text.getBytes());
+        Map<String, byte[]> properties = new HashMap<>();
+        properties.put(SERVICE_KEY, text.getBytes());
         service = ServiceInfo.create("_HtmL._TcP.lOcAl.", "apache-someUniqueid", 80, 0, 0, true, properties);
-        JmDNS registry = null;
-        try {
-            registry = JmDNS.create();
+        try (JmDNS registry = JmDNS.create()) {
             registry.registerService(service);
 
             // without toLowerCase
             ServiceInfo[] services = registry.list(service.getType());
-            assertEquals("We should see the service we just registered: ", 1, services.length);
+            assertEquals(1, services.length, "We should see the service we just registered: ");
             assertEquals(service, services[0]);
             // now unregister and make sure it's gone
             registry.unregisterService(services[0]);
@@ -566,50 +444,49 @@ public class JmDNSTest {
             // without sleeping for a while, the service would not be unregistered fully
             Thread.sleep(1500);
             services = registry.list(service.getType());
-            assertTrue("We should not see the service we just unregistered: ", services == null || services.length == 0);
-        } finally {
-            if (registry != null) registry.close();
+            assertTrue(services == null || services.length == 0, "We should not see the service we just unregistered: ");
         }
     }
 
     @Test
-    public void shouldNotNotifyServiceListenersForServiceResolveAfterServiceRemoved() throws UnknownHostException, IOException, InterruptedException {
+    void shouldNotNotifyServiceListenersForServiceResolveAfterServiceRemoved() throws IOException, InterruptedException {
         String firstType = "_test._type1.local.";
-        String secondType = "_test._type2.local.";
 
-        JmmDNS jmmdns = JmmDNS.Factory.getInstance();
+        try (JmmDNS jmmdns = JmmDNS.Factory.getInstance()) {
+            Thread.sleep(5000);
 
-        EventStoringServiceListener firstListener = new EventStoringServiceListener(firstType);
-        jmmdns.addServiceListener(firstType, firstListener);
+            EventStoringServiceListener firstListener = new EventStoringServiceListener(firstType);
+            jmmdns.addServiceListener(firstType, firstListener);
 
-        InetAddress[] addresses = jmmdns.getInetAddresses();
-        JmDNS[] dns = new JmDNS[addresses.length];
-        Map<String, String> txtRecord = new HashMap<String, String>();
-        txtRecord.put("SOME KEY", "SOME VALUE");
+            InetAddress[] addresses = jmmdns.getInetAddresses();
+            JmDNS[] dns = new JmDNS[addresses.length];
+            Map<String, String> txtRecord = new HashMap<>();
+            txtRecord.put("SOME KEY", "SOME VALUE");
 
-        ServiceInfo info = ServiceInfo.create(firstType, "SOME TEST NAME", 4444, 0, 0, true, txtRecord);
+            ServiceInfo info = ServiceInfo.create(firstType, "SOME TEST NAME", 4444, 0, 0, true, txtRecord);
 
-        for (int i = 0; i < addresses.length; i++) {
-            dns[i] = JmDNS.create(addresses[i], null);
-            dns[i].registerService(info.clone());
+            for (int i = 0; i < addresses.length; i++) {
+                dns[i] = JmDNS.create(addresses[i], null);
+                dns[i].registerService(info.clone());
+            }
+
+
+            assertTrue(firstListener.isServiceAddedReceived());
+            assertTrue(firstListener.isServiceResolvedReceived());
+            assertFalse(firstListener.isServiceRemovedReceived());
+
+            Thread.sleep(30 * 1000);
+
+            firstListener.reset();
+
+            for (JmDNS dn : dns) {
+                dn.close();
+            }
+
+            assertFalse(firstListener.isServiceAddedReceived());
+            assertTrue(firstListener.isServiceRemovedReceived());
+            assertFalse(firstListener.isServiceResolvedReceived());
         }
-
-        assertTrue(firstListener.isServiceAddedReceived());
-        assertTrue(firstListener.isServiceResolvedReceived());
-        assertFalse(firstListener.isServiceRemovedReceived());
-
-        Thread.sleep(30 * 1000);
-
-        firstListener.reset();
-
-        for (int i = 0; i < dns.length; i++) {
-            dns[i].close();
-        }
-
-        assertFalse(firstListener.isServiceAddedReceived());
-        assertTrue(firstListener.isServiceRemovedReceived());
-
-        assertFalse(firstListener.isServiceResolvedReceived());
     }
 
 }

--- a/src/test/java/javax/jmdns/impl/ServiceInfoImplTest.java
+++ b/src/test/java/javax/jmdns/impl/ServiceInfoImplTest.java
@@ -13,30 +13,38 @@
  */
 package javax.jmdns.impl;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.DatagramPacket;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author stefan eicher
  */
-public class ServiceInfoImplTest {
+class ServiceInfoImplTest {
 
+    @BeforeEach
+    public void before() throws IOException {
+        jmDNS = new JmDNSImpl(null, null);
+    }
+
+    @AfterEach
+    public void after() {
+        if (jmDNS != null) jmDNS.close();
+    }
 
     private JmDNSImpl jmDNS;
 
     @Test
-    public void test_ip_address_is_set() throws Exception {
+    void testGetInet4Addresses() throws Exception {
         byte[] buf = readFile("a_record_before_srv.bin");
         DNSIncoming msg = new DNSIncoming(new DatagramPacket(buf, buf.length));
-        jmDNS = new JmDNSImpl(null, null);
         ServiceInfoImpl serviceInfo = new ServiceInfoImpl(
                 "_ibisip_http._tcp.local.",
                 "DeviceManagementService",
@@ -49,22 +57,16 @@ public class ServiceInfoImplTest {
         jmDNS.addListener(serviceInfo, null);
         jmDNS.handleResponse(msg);
 
-
-        //Assure init values are overwritten and that ..
-        assertEquals(serviceInfo.getServer(), "DIST500_7-F07_OC030_05_03941.local.");
-        assertEquals(serviceInfo.getPort(), 5000);
-        assertEquals(serviceInfo.getWeight(), 0);
-        assertEquals(serviceInfo.getPriority(), 0);
-        assertEquals(serviceInfo.isPersistent(), true);
+        //Assure init values are overwritten and that
+        assertEquals("DIST500_7-F07_OC030_05_03941.local.", serviceInfo.getServer());
+        assertEquals(5000, serviceInfo.getPort());
+        assertEquals(0, serviceInfo.getWeight());
+        assertEquals(0, serviceInfo.getPriority());
+        assertTrue(serviceInfo.isPersistent());
 
         // ... the ip address is set
-        assertEquals(serviceInfo.getInet4Addresses().length, 1);
+        assertEquals(1, serviceInfo.getInet4Addresses().length);
         assertArrayEquals(serviceInfo.getInet4Addresses()[0].getAddress(), new  byte[]{(byte) 192, (byte) 168,88, (byte) 236});
-    }
-
-    @After
-    public void after() {
-        if (jmDNS != null) jmDNS.close();
     }
 
     private byte[] readFile(String fileName) throws IOException {

--- a/src/test/java/javax/jmdns/impl/ServiceTypeDecoderTest.java
+++ b/src/test/java/javax/jmdns/impl/ServiceTypeDecoderTest.java
@@ -13,56 +13,56 @@
  */
 package javax.jmdns.impl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.jmdns.ServiceInfo;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ServiceTypeDecoderTest {
+class ServiceTypeDecoderTest {
 
     @Test
-    public void decodeItxptStyle() {
+    void decodeItxptStyle() {
         assertDecodeProperly("aabbcc11eeff._apc._itxpt_http._tcp.local.", "aabbcc11eeff._apc", "itxpt_http", "tcp", "local", "");
     }
 
     @Test
-    public void decodeWithoutDot() {
+    void decodeWithoutDot() {
         assertDecodeProperly("any_instance_name._http._tcp.local.", "any_instance_name", "http", "tcp", "local", "");
     }
 
     @Test
-    public void decodeWithSubtype() {
+    void decodeWithSubtype() {
         assertDecodeProperly("_printer._sub._http._tcp.local.", "", "http", "tcp", "local", "printer");
         assertDecodeProperly("4c33057a._sub._apple-mobdev2._tcp.local.", "", "apple-mobdev2", "tcp", "local", "4c33057a");
         assertDecodeProperly("abb22cc._sub._apple-mobdev2._tcp.local.", "", "apple-mobdev2", "tcp", "local", "abb22cc");
     }
 
     @Test
-    public void decodeWithSubtype2() {
+    void decodeWithSubtype2() {
         assertDecodeProperly("abcde._printer._sub._http._tcp.local.", "abcde", "http", "tcp", "local", "printer");
     }
 
     @Test
-    public void decode() {
+    void decode() {
         Map<ServiceInfo.Fields, String> actual = ServiceTypeDecoder.decodeQualifiedNameMapForType("DIST123_7-F07_OC030_05_03941.local.");
         Map<ServiceInfo.Fields, String> expected = ServiceInfoImpl.createQualifiedMap("DIST123_7-F07_OC030_05_03941", "", "", "local", "");
         assertEquals(expected, actual);
     }
 
     @Test
-    public void decode2() {
+    void decode2() {
         assertDecodeProperly("DeviceManagementService._ibisip_http._tcp.local.", "DeviceManagementService", "ibisip_http", "tcp", "local", "");
     }
 
     @Test
-    public void decode3() {
+    void decode3() {
         assertDecodeProperly("_ibisip_http._tcp.local.", "", "ibisip_http", "tcp", "local", "");
     }
 
     @Test
-    public void decode4() {
+    void decode4() {
         assertDecodeProperly("_itxpt_http._tcp.local", "", "itxpt_http", "tcp", "local", "");
         assertDecodeProperly("_itxpt_http._tcp.local.", "", "itxpt_http", "tcp", "local", "");
         assertDecodeProperly("ABC-PC2-berlin-company-com.local.", "ABC-PC2-berlin-company-com", "", "", "local", "");
@@ -73,7 +73,7 @@ public class ServiceTypeDecoderTest {
     }
 
     @Test
-    public void decode5() {
+    void decode5() {
         assertDecodeProperly("abc123-0000-00000-3.local.", "abc123-0000-00000-3", "", "", "local", "");
         assertDecodeProperly("HP LaserJet 10000 colorMFP M570dw (A11111F)._ipps._tcp.local.", "HP LaserJet 10000 colorMFP M570dw (A11111F)", "ipps", "tcp", "local", "");
         assertDecodeProperly("HP LaserJet 700 color MFP M775 [520D0D]._privet._tcp.local.", "HP LaserJet 700 color MFP M775 [520D0D]", "privet", "tcp", "local", "");
@@ -85,7 +85,7 @@ public class ServiceTypeDecoderTest {
     }
 
     @Test
-    public void testDecodeQualifiedNameMap() {
+    void testDecodeQualifiedNameMap() {
         String domain = "test.com";
         String protocol = "udp";
         String application = "ftp";
@@ -96,15 +96,15 @@ public class ServiceTypeDecoderTest {
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMap(type, name, subtype);
 
-        assertEquals("We did not get the right domain:", domain, map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", protocol, map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", application, map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", name, map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", subtype, map.get(ServiceInfo.Fields.Subtype));
+        assertEquals(domain, map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals(protocol, map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals(application, map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals(name, map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals(subtype, map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeQualifiedNameMapDefaults() {
+    void testDecodeQualifiedNameMapDefaults() {
         String domain = "local";
         String protocol = "tcp";
         String application = "ftp";
@@ -113,209 +113,206 @@ public class ServiceTypeDecoderTest {
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMap(application, name, subtype);
 
-        assertEquals("We did not get the right domain:", domain, map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", protocol, map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", application, map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", name, map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", subtype, map.get(ServiceInfo.Fields.Subtype));
+        assertEquals(domain, map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals(protocol, map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals(application, map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals(name, map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals(subtype, map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceType() {
+    void testDecodeServiceType() {
         String type = "_home-sharing._tcp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "tcp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "home-sharing", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
-
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("tcp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("home-sharing", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceWithUnderscoreType() {
+    void testDecodeServiceWithUnderscoreType() {
         String type = "_x_lumenera_mjpeg1._udp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "udp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "x_lumenera_mjpeg1", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
-
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("udp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("x_lumenera_mjpeg1", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceTCPType() {
+    void testDecodeServiceTCPType() {
         String type = "_afpovertcp._tcp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "tcp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "afpovertcp", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("tcp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("afpovertcp", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceTypeWithSubType() {
+    void testDecodeServiceTypeWithSubType() {
         String type = "_00000000-0b44-f234-48c8-071c565644b3._sub._home-sharing._tcp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "tcp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "home-sharing", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "00000000-0b44-f234-48c8-071c565644b3", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("tcp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("home-sharing", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("00000000-0b44-f234-48c8-071c565644b3", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceName() {
+    void testDecodeServiceName() {
         String type = "My New Itunes Service._home-sharing._tcp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "tcp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "home-sharing", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "My New Itunes Service", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("tcp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("home-sharing", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("My New Itunes Service", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceNameWithSpecialCharacter() {
+    void testDecodeServiceNameWithSpecialCharacter() {
         String type = "&test._home-sharing._tcp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "tcp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "home-sharing", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "&test", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("tcp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("home-sharing", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("&test", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeDNSMetaQuery() {
+    void testDecodeDNSMetaQuery() {
         String type = "_services._dns-sd._udp.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "udp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "dns-sd", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "_services", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("udp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("dns-sd", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("_services", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testReverseDNSQuery() {
+    void testReverseDNSQuery() {
         String type = "100.50.168.192.in-addr.arpa.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "in-addr.arpa", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "100.50.168.192", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("in-addr.arpa", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("100.50.168.192", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testAddress() {
+    void testAddress() {
         String type = "panoramix.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "panoramix", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("panoramix", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testAddressPreserveCase() {
+    void testAddressPreserveCase() {
         String type = "pano_RAmix.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "pano_RAmix", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("pano_RAmix", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testNameWithUnderscore() {
+    void testNameWithUnderscore() {
         String type = "pano_ramix.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "pano_ramix", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("pano_ramix", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testNameWithSpecialChar() {
+    void testNameWithSpecialChar() {
         String type = "panoramİx.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "panoramİx", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("panoramİx", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testCasePreserving() {
+    void testCasePreserving() {
         String type = "My New Itunes Service._Home-Sharing._TCP.Panoramix.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "Panoramix.local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "TCP", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "Home-Sharing", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "My New Itunes Service", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("Panoramix.local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("TCP", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("Home-Sharing", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("My New Itunes Service", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testCasePreservingSpecialChar() {
+    void testCasePreservingSpecialChar() {
         String type = "aBcİ._Home-Sharing._TCP.Panoramix.local.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "Panoramix.local", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "TCP", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "Home-Sharing", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "aBcİ", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
+        assertEquals("Panoramix.local", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("TCP", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("Home-Sharing", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("aBcİ", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     @Test
-    public void testDecodeServiceTypeMissingDomain() {
+    void testDecodeServiceTypeMissingDomain() {
         String type = "myservice._ftp._tcp.";
 
         Map<ServiceInfo.Fields, String> map = ServiceTypeDecoder.decodeQualifiedNameMapForType(type);
 
-        assertEquals("We did not get the right domain:", "", map.get(ServiceInfo.Fields.Domain));
-        assertEquals("We did not get the right protocol:", "tcp", map.get(ServiceInfo.Fields.Protocol));
-        assertEquals("We did not get the right application:", "ftp", map.get(ServiceInfo.Fields.Application));
-        assertEquals("We did not get the right name:", "myservice", map.get(ServiceInfo.Fields.Instance));
-        assertEquals("We did not get the right subtype:", "", map.get(ServiceInfo.Fields.Subtype));
-
+        assertEquals("", map.get(ServiceInfo.Fields.Domain), "We did not get the right domain:");
+        assertEquals("tcp", map.get(ServiceInfo.Fields.Protocol), "We did not get the right protocol:");
+        assertEquals("ftp", map.get(ServiceInfo.Fields.Application), "We did not get the right application:");
+        assertEquals("myservice", map.get(ServiceInfo.Fields.Instance), "We did not get the right name:");
+        assertEquals("", map.get(ServiceInfo.Fields.Subtype), "We did not get the right subtype:");
     }
 
     private void assertDecodeProperly(String type, String... qualifiedMap) {

--- a/src/test/java/javax/jmdns/test/DNSStatefulObjectTest.java
+++ b/src/test/java/javax/jmdns/test/DNSStatefulObjectTest.java
@@ -13,76 +13,77 @@
  */
 package javax.jmdns.test;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.jmdns.impl.DNSStatefulObject.DNSStatefulObjectSemaphore;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DNSStatefulObjectTest {
+class DNSStatefulObjectTest {
 
-    public static final class WaitingThread extends Thread {
+    private static final class WaitingThread extends Thread {
 
-        private final DNSStatefulObjectSemaphore _semaphore;
-        private final long                       _timeout;
+        private final DNSStatefulObjectSemaphore semaphore;
+        private final long timeout;
 
-        private boolean _hasFinished;
+        private boolean hasFinished;
 
         public WaitingThread(DNSStatefulObjectSemaphore semaphore, long timeout) {
             super("Waiting thread");
-            _semaphore = semaphore;
-            _timeout = timeout;
-            _hasFinished = false;
+            this.semaphore = semaphore;
+            this.timeout = timeout;
+            hasFinished = false;
         }
 
         @Override
         public void run() {
-            _semaphore.waitForEvent(_timeout);
-            _hasFinished = true;
+            semaphore.waitForEvent(timeout);
+            hasFinished = true;
         }
 
         /**
          * @return the hasFinished
          */
         public boolean hasFinished() {
-            return _hasFinished;
+            return hasFinished;
         }
 
     }
 
-    DNSStatefulObjectSemaphore _semaphore;
+    DNSStatefulObjectSemaphore semaphore;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        _semaphore = new DNSStatefulObjectSemaphore("test");
+        semaphore = new DNSStatefulObjectSemaphore("test");
     }
 
-    @After
+    @AfterEach
     public void teardown() {
-        _semaphore = null;
+        semaphore = null;
     }
 
     @Test
-    public void testWaitAndSignal() throws InterruptedException {
-        WaitingThread thread = new WaitingThread(_semaphore, Long.MAX_VALUE);
+    void testWaitAndSignal() throws InterruptedException {
+        WaitingThread thread = new WaitingThread(semaphore, Long.MAX_VALUE);
         thread.start();
         Thread.sleep(1);
-        assertFalse("The thread should be waiting.", thread.hasFinished());
-        _semaphore.signalEvent();
+        assertFalse(thread.hasFinished(), "The thread should be waiting.");
+        semaphore.signalEvent();
         Thread.sleep(1);
-        assertTrue("The thread should have finished.", thread.hasFinished());
+        assertTrue(thread.hasFinished(), "The thread should have finished.");
     }
 
     @Test
-    public void testWaitAndTimeout() throws InterruptedException {
-        WaitingThread thread = new WaitingThread(_semaphore, 100);
+    void testWaitAndTimeout() throws InterruptedException {
+        WaitingThread thread = new WaitingThread(semaphore, 100);
         thread.start();
         Thread.sleep(1);
-        assertFalse("The thread should be waiting.", thread.hasFinished());
+        assertFalse(thread.hasFinished(), "The thread should be waiting.");
         Thread.sleep(150);
-        assertTrue("The thread should have finished.", thread.hasFinished());
+        assertTrue(thread.hasFinished(), "The thread should have finished.");
     }
 
 }

--- a/src/test/java/javax/jmdns/test/EventContainer.java
+++ b/src/test/java/javax/jmdns/test/EventContainer.java
@@ -11,7 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.impl;
+package javax.jmdns.test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -20,7 +23,9 @@ import javax.jmdns.ServiceEvent;
 
 public class EventContainer {
 
-    private final Map<String, ServiceEvent> events = new LinkedHashMap<String, ServiceEvent>();
+    private static final Logger logger = LoggerFactory.getLogger(EventContainer.class);
+
+    private final Map<String, ServiceEvent> events = new LinkedHashMap<>();
 
     private boolean eventReceived;
 
@@ -58,7 +63,7 @@ public class EventContainer {
                     eventReceived = events.containsKey(serviceType);
                     eventVerificationCount++;
                 } catch (InterruptedException exception) {
-                    exception.printStackTrace();
+                    logger.error("InterruptedException during waiting", exception);
                 }
             }
         }

--- a/src/test/java/javax/jmdns/test/EventStoringServiceListener.java
+++ b/src/test/java/javax/jmdns/test/EventStoringServiceListener.java
@@ -11,18 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.impl;
+package javax.jmdns.test;
 
 import javax.jmdns.ServiceEvent;
 import javax.jmdns.ServiceListener;
 
 public class EventStoringServiceListener implements ServiceListener {
 
-    private EventContainer addedEvents    = new EventContainer();
-    private EventContainer removedEvents  = new EventContainer();
-    private EventContainer resolvedEvents = new EventContainer();
+    private final EventContainer addedEvents = new EventContainer();
+    private final EventContainer removedEvents = new EventContainer();
+    private final EventContainer resolvedEvents = new EventContainer();
 
-    private final String   serviceType;
+    private final String serviceType;
 
     public EventStoringServiceListener(String serviceType) {
         this.serviceType = serviceType;

--- a/src/test/java/javax/jmdns/test/ServiceInfoTest.java
+++ b/src/test/java/javax/jmdns/test/ServiceInfoTest.java
@@ -13,7 +13,7 @@
  */
 package javax.jmdns.test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -23,57 +23,47 @@ import java.util.Set;
 
 import javax.jmdns.ServiceInfo;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ServiceInfoTest {
+class ServiceInfoTest {
 
-    @Before
-    public void setup() {
-        // Placeholder
+    @Test
+    void testEncodeDecodeProperties() {
+        String serviceType = "_ros-master._tcp.local.";
+        String serviceName = "RosMaster";
+        int servicePort = 8888;
+        String serviceKey = "description"; // Max 9 chars
+        String serviceText = "Hypothetical ros master";
+        Map<String, byte[]> properties = new HashMap<>();
+        properties.put(serviceKey, serviceText.getBytes());
+        ServiceInfo serviceInfo = ServiceInfo.create(serviceType, serviceName, servicePort, ""); // case 1, no text
+        assertNull(serviceInfo.getPropertyString(serviceKey), "We should have got the same properties (Empty):");
+        serviceInfo = ServiceInfo.create(serviceType, serviceName, servicePort, 0, 0, true, serviceKey + "=" + serviceText); // case 2, textual description
+        assertEquals(serviceText, serviceInfo.getPropertyString(serviceKey), "We should have got the same properties (String):");
+        serviceInfo = ServiceInfo.create(serviceType, serviceName, servicePort, 0, 0, true, properties); // case 3, properties assigned textual description
+        assertEquals(serviceText, serviceInfo.getPropertyString(serviceKey), "We should have got the same properties (Map):");
     }
 
     @Test
-    public void testEncodeDecodeProperties() {
-
-        String service_type = "_ros-master._tcp.local.";
-        String service_name = "RosMaster";
-        int service_port = 8888;
-        String service_key = "description"; // Max 9 chars
-        String service_text = "Hypothetical ros master";
-        Map<String, byte[]> properties = new HashMap<String, byte[]>();
-        properties.put(service_key, service_text.getBytes());
-        ServiceInfo service_info = null;
-        service_info = ServiceInfo.create(service_type, service_name, service_port, ""); // case 1, no text
-        assertEquals("We should have got the same properties (Empty):", null, service_info.getPropertyString(service_key));
-        service_info = ServiceInfo.create(service_type, service_name, service_port, 0, 0, true, service_key + "=" + service_text); // case 2, textual description
-        assertEquals("We should have got the same properties (String):", service_text, service_info.getPropertyString(service_key));
-        service_info = ServiceInfo.create(service_type, service_name, service_port, 0, 0, true, properties); // case 3, properties assigned textual description
-        assertEquals("We should have got the same properties (Map):", service_text, service_info.getPropertyString(service_key));
-
-    }
-
-    @Test
-    public void testDecodePropertiesWithoutEqualsSign() {
-        String service_type = "_ros-master._tcp.local.";
-        String service_name = "RosMaster";
-        int service_port = 8888;
-        ServiceInfo service_info = null;
+    void testDecodePropertiesWithoutEqualsSign() {
+        String serviceType = "_ros-master._tcp.local.";
+        String serviceName = "RosMaster";
+        int serviceOort = 8888;
         // Represents TXT records "a" "b=c"
         byte[] txt = {1, 97, 3, 98, 61, 99};
-        service_info = ServiceInfo.create(service_type, service_name, service_port, 0, 0, txt);
+        ServiceInfo serviceInfo = ServiceInfo.create(serviceType, serviceName, serviceOort, 0, 0, txt);
 
-        Set<String> expectedKeys = new HashSet<String>();
+        Set<String> expectedKeys = new HashSet<>();
         expectedKeys.add("a");
         expectedKeys.add("b");
 
-        Enumeration<String> enumeration = service_info.getPropertyNames();
-        Set<String> keys = new HashSet<String>();
+        Enumeration<String> enumeration = serviceInfo.getPropertyNames();
+        Set<String> keys = new HashSet<>();
         while (enumeration.hasMoreElements()) {
             keys.add(enumeration.nextElement());
         }
         assertEquals(expectedKeys, keys);
-        assertEquals("c", service_info.getPropertyString("b"));
+        assertEquals("c", serviceInfo.getPropertyString("b"));
     }
-
 }

--- a/src/test/java/javax/jmdns/test/extensions/TestNameLogger.java
+++ b/src/test/java/javax/jmdns/test/extensions/TestNameLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javax.jmdns.test.extensions;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class TestNameLogger implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+    private static final Logger logger = LoggerFactory.getLogger(TestNameLogger.class);
+
+    @Override
+    public void beforeTestExecution(ExtensionContext extensionContext) {
+        logger.info("{}.{}() starting", extensionContext.getRequiredTestClass().getName(),
+                extensionContext.getRequiredTestMethod().getName());
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext extensionContext) {
+        logger.info("{}.{}() finished", extensionContext.getRequiredTestClass().getName(),
+            extensionContext.getRequiredTestMethod().getName());
+    }
+}

--- a/src/test/java/javax/jmdns/test/util/ReflectionUtils.java
+++ b/src/test/java/javax/jmdns/test/util/ReflectionUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javax.jmdns.test.util;
+
+import java.lang.reflect.Field;
+
+public class ReflectionUtils {
+    private ReflectionUtils() {
+        // intentionally left blank
+    }
+
+    public static void setInternalState(Object targetObject, String fieldName, Object value) throws Exception {
+        Field field = targetObject.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);  // Make the field accessible
+        field.set(targetObject, value);  // Set the new value
+    }
+
+    public static Object getInternalState(Object targetObject, String fieldName) throws NoSuchFieldException, IllegalAccessException {
+        Field field = targetObject.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(targetObject);
+    }
+}

--- a/src/test/java/javax/jmdns/test/util/StringUtil.java
+++ b/src/test/java/javax/jmdns/test/util/StringUtil.java
@@ -11,14 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package util;
+package javax.jmdns.test.util;
 
 import java.nio.charset.Charset;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StringUtil {
     
@@ -42,7 +43,7 @@ public class StringUtil {
         UNICODE_CHARACTERS = sb.toString();
     }
 
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     public static String randomAsciiString(final int length) {
         final StringBuilder sb = new StringBuilder();
@@ -130,7 +131,7 @@ public class StringUtil {
             bytes = str.getBytes(UTF_8);
         }
 
-        // since we we might have removed a Unicode character 
+        // since we might have removed a Unicode character
         // we might now be some bytes of in the wrong direction
         while(bytes.length < length) {
             str = str + 'X';
@@ -152,7 +153,7 @@ public class StringUtil {
         final String str = maxSizeRandomString(length);
 
         final byte[] bytes = str.getBytes(UTF_8);
-        assertEquals("Create bytes array", length, bytes.length);
+        assertEquals(length, bytes.length, "Create bytes array");
 
         final byte[] result = new byte[bytes.length + 1];
         result[0] = (byte) (bytes.length & 0xFF);

--- a/src/test/java/javax/jmdns/util/ByteWranglerTest.java
+++ b/src/test/java/javax/jmdns/util/ByteWranglerTest.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.util.test;
+package javax.jmdns.util;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
-
 import javax.jmdns.impl.util.ByteWrangler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static util.StringUtil.*;
+import static javax.jmdns.test.util.StringUtil.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ByteWranglerTest {
+class ByteWranglerTest {
 
     @Test
-    public void testEmptyString() throws IOException {
+    void testEmptyString() throws IOException {
         final String emtpyString = "";
 
         // contains only one byte
@@ -34,14 +34,13 @@ public class ByteWranglerTest {
         // - otherwise no data
         final byte[] text = ByteWrangler.encodeText(emtpyString);
 
-        assertEquals("Resulting byte array length", 1, text.length);
-        assertEquals("Resulting byte array", 0, text[0]);
-
-        assertArrayEquals("Resulting byte array", ByteWrangler.EMPTY_TXT, text);
+        assertEquals(1, text.length ,"Resulting byte array length");
+        assertEquals(0, text[0], "Resulting byte array");
+        assertArrayEquals(ByteWrangler.EMPTY_TXT, text, "Resulting byte array");
     }
 
     @Test
-    public void testJustLongString() throws IOException {
+    void testJustLongString() throws IOException {
         final int length = 255;
 
         final String randomString = randomAsciiString(length);
@@ -51,31 +50,30 @@ public class ByteWranglerTest {
         // - byte[1-length] contains data
         final byte[] text = ByteWrangler.encodeText(randomString);
 
-        assertEquals("Resulting byte array length", length+1, text.length);
+        assertEquals(length + 1, text.length, "Resulting byte array length");
     }
 
     @Test
-    public void testTooLongString() throws IOException {
+    void testTooLongString() throws IOException {
 
         final String randomString = randomAsciiString(256);
 
         final byte[] text = ByteWrangler.encodeText(randomString);
 
-        assertEquals("Byte array should be empty because its too long", ByteWrangler.EMPTY_TXT, text);
+        assertEquals(ByteWrangler.EMPTY_TXT, text, "Byte array should be empty because its too long");
     }
 
-
     @Test
-    public void testTooLongNonAsciiString() throws IOException {
+    void testTooLongNonAsciiString() throws IOException {
         final String randomString = maxSizeRandomString(256);
 
         final byte[] text = ByteWrangler.encodeText(randomString);
 
-        assertEquals("Byte array should be empty because its too long", ByteWrangler.EMPTY_TXT, text);
+        assertEquals(ByteWrangler.EMPTY_TXT, text, "Byte array should be empty because its too long");
     }
 
     @Test
-    public void testJustLongNonAsciiString() throws IOException {
+    void testJustLongNonAsciiString() throws IOException {
         final int length = 255;
 
         final String str = maxSizeRandomString(length);
@@ -86,15 +84,15 @@ public class ByteWranglerTest {
         // - byte[1-length] contains data
         final byte[] text = ByteWrangler.encodeText(str);
 
-        assertEquals("Resulting byte array length", bytes.length+1, text.length);
+        assertEquals(bytes.length + 1, text.length, "Resulting byte array length");
 
-        for (int i = 0; i < bytes.length; i++ ) {
-            assertEquals("Resulting byte array", bytes[i], text[i+1]);
+        for (int i = 0; i < bytes.length; i++) {
+            assertEquals(bytes[i], text[i + 1], "Resulting byte array");
         }
     }
 
     @Test
-    public void testReadingUTF() {
+    void testReadingUTF() {
         final int length = 255;
 
         final String str = maxSizeRandomString(length);
@@ -103,8 +101,8 @@ public class ByteWranglerTest {
         // no read the String back using the ByteWrangler method
         final String readStr = ByteWrangler.readUTF(bytes, 0, bytes.length);
 
-        assertEquals("Resulting String length", str.length(), readStr.length());
-        assertEquals("Resulting String", str, readStr);
+        assertEquals(str.length(), readStr.length(), "Resulting String length");
+        assertEquals(str, readStr, "Resulting String");
     }
 
 }

--- a/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+javax.jmdns.test.extensions.TestNameLogger

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true


### PR DESCRIPTION
- [x] Upgrade to JUnit5. 
- [x] Remove easymock.
- [x] Add logback-classic for tests.
- [x] Make tests 'green'

I wanted to move the below listed files under `javax.jmdns.impl` package, but it needs to be a separate PR (even if they are moved, git cannot preserve their history).
- _DNSStatefulObjectTest.java_
- _JmmDNSTest.java_
- _ServiceInfoTest.java_
- _TextUpdateTest.java_

**No goal:**
- optimize on tests (performance)
- stabilize tests (I can not guarantee there aren't any `flaky` tests)
- remove duplicate tests
- since more or less all `JmDNS` and `JmmDNS` tests are multi-threaded, it was no goal to remove `Thread.sleep()`
