### PR TITLE
Downgrade logback-classic test dependency to be compatible with JDK8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-		<jvm.version>1.8</jvm.version>
+		<jvm.version>8</jvm.version>
 		<mockito.version>4.11.0</mockito.version>
 	</properties>
 
@@ -76,7 +76,7 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.6</version>
+			<version>1.3.14</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -97,10 +97,11 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.13.0</version>
 				<configuration>
 					<source>${jvm.version}</source>
 					<target>${jvm.version}</target>
+					<release>${jvm.version}</release>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Fixes #324

@ViToni  @kaikreuzer  @melloware 
With a parallel PR https://github.com/jmdns/jmdns/pull/318 I've introduced a _logback-classic_ dependency which is not compatible with JDK8 builds (similarly as _mockito_)

- Downgrade logback-classic test dependency to be compatible with JDK8
- Upgrade maven-compiler-plugin to 3.13.0 (more info about its [use under JDK8](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html#usage-on-jdk-8) and see related [JEP](https://openjdk.org/jeps/247)).