### PR TITLE
TEST_ONLY Move test classes under javax.jmdns.impl package.

### DIFF
--- a/src/test/java/javax/jmdns/impl/DNSStatefulObjectTest.java
+++ b/src/test/java/javax/jmdns/impl/DNSStatefulObjectTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.test;
+package javax.jmdns.impl;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/javax/jmdns/impl/JmmDNSTest.java
+++ b/src/test/java/javax/jmdns/impl/JmmDNSTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.test;
+package javax.jmdns.impl;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/javax/jmdns/impl/ServiceInfoTest.java
+++ b/src/test/java/javax/jmdns/impl/ServiceInfoTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.test;
+package javax.jmdns.impl;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/javax/jmdns/impl/TextUpdateTest.java
+++ b/src/test/java/javax/jmdns/impl/TextUpdateTest.java
@@ -11,11 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package javax.jmdns.test;
+package javax.jmdns.impl;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceEvent;


### PR DESCRIPTION
This is a continuation of https://github.com/jmdns/jmdns/pull/318. I couldn't move these files within the same PR.