### PR TITLE
fix checking of unicast or multicast answers

### DIFF
--- a/src/main/java/javax/jmdns/impl/SocketListener.java
+++ b/src/main/java/javax/jmdns/impl/SocketListener.java
@@ -75,8 +75,6 @@ class SocketListener extends Thread {
                             // When we have a QUERY, unique means that QU is true, and we should respond to the sender directly
                             if (msg.getQuestions().stream().anyMatch(DNSEntry::isUnique)) {
                                 this._jmDNSImpl.handleQuery(msg, packet.getAddress(), packet.getPort());
-                            } else if (packet.getPort() != DNSConstants.MDNS_PORT) {
-                                this._jmDNSImpl.handleQuery(msg, packet.getAddress(), packet.getPort());
                             } else {
                                 this._jmDNSImpl.handleQuery(msg, this._jmDNSImpl.getGroup(), DNSConstants.MDNS_PORT);
                             }


### PR DESCRIPTION
According to RFC 6762, all Multicast DNS traffic MUST use UDP port 5353. This applies to the destination port, not the source port. We can be certain that the destination of the DatagramPacket is using port 5353 since we are joining on the group using that port. Therefore, the port check is not necessary.

Fixes #343 