### PR TITLE
Remove dependency on osgi.ee from Manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@ The project was originally started in December 2002 by Arthur van Hoff at Strang
 				<configuration>
 					<manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
 					<instructions>
+						<_noee>true</_noee>
 						<Bundle-SymbolicName>javax.jmdns</Bundle-SymbolicName>
 						<Export-Package>javax.jmdns</Export-Package>
 						<Private-Package>javax.jmdns.impl,javax.jmdns.impl.*,com.strangeberry.*,samples</Private-Package>


### PR DESCRIPTION
Bundle-RequiredExecutionEnvironment already defines the minimum Java version. Requiring osgi.ee as capability may cause problems when using this library.

This PR should remove
<img width="303" height="32" alt="grafik" src="https://github.com/user-attachments/assets/297e3d5a-003d-4bc3-8af3-c19aec2e8ece" />
from MANIFEST.

@kaikreuzer FYI