### PR TITLE
Fix requestServiceInfo() timeout

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -891,7 +891,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
      */
     @Override
     public void requestServiceInfo(String type, String name, long timeout) {
-        this.requestServiceInfo(type, name, false, DNSConstants.SERVICE_INFO_TIMEOUT);
+        this.requestServiceInfo(type, name, false, timeout);
     }
 
     /**


### PR DESCRIPTION
I was looking at the code to try to figure out how to use JmDNS without too much blocking, when I discovered this. As far as I can understand, it has to be a bug.

That said, I don't understand why `requestServiceInfo()` has a timeout at all, since it doesn't return any data and you're supposed to get the results asynchronously via a listener. The "workaround" is to set a really short timeout, which doesn't work for obvious reasons.