### PR TITLE
Fix printing JmDNS version

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -381,7 +381,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
         String version;
         try {
             final Properties pomProperties = new Properties();
-            pomProperties.load(JmDNSImpl.class.getResourceAsStream("/META-INF/maven/javax.jmdns/jmdns/pom.properties"));
+            pomProperties.load(JmDNSImpl.class.getResourceAsStream("/META-INF/maven/org.jmdns/jmdns/pom.properties"));
             version = pomProperties.getProperty("version");
         } catch (Exception e) {
             version = "RUNNING.IN.IDE.FULL";


### PR DESCRIPTION
Before, running the JmDNS JAR would always print

```text
$ java -jar target/jmdns-3.6.4-SNAPSHOT.jar
JmDNS version "RUNNING.IN.IDE.FULL"
```

After this change, it'll print

```text
$ java -jar target/jmdns-3.6.4-SNAPSHOT.jar
JmDNS version "3.6.4-SNAPSHOT"
```