### PR TITLE
Fix #203: bind the host address so a VPN cannot steal the multicast source

### DIFF
--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -485,9 +485,14 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
     }
 
     private InetSocketAddress getMulticastBindAddress(HostInfo hostInfo) {
-        if (IS_WINDOWS && JAVA_VERSION >= 17) {
-			// JDK17+ removed TwoStacksPlainDatagramSocketImpl which causes a stack trace
-			// on Windows JDK < 17 so this constructor is required
+        if (IS_WINDOWS && JAVA_VERSION < 17) {
+            // JDK17+ removed TwoStacksPlainDatagramSocketImpl which causes a stack trace
+            // on Windows JDK < 17, so those versions keep the wildcard bind (#356).
+            return new InetSocketAddress(DNSConstants.MDNS_PORT);
+        } else if (hostInfo != null && hostInfo.getInetAddress() != null) {
+            // Binding the host address fixes the source address of outgoing multicast. A wildcard
+            // bind leaves that choice to the routing table, which a VPN can own, so packets go out
+            // the LAN interface carrying an off-link source and receivers drop them (#203).
             return new InetSocketAddress(hostInfo.getInetAddress(), DNSConstants.MDNS_PORT);
         } else {
             return new InetSocketAddress(DNSConstants.MDNS_PORT);


### PR DESCRIPTION
Fixes #203.

## What goes wrong

`getMulticastBindAddress` binds the wildcard everywhere except Windows on JDK 17+. A wildcard bind
leaves the source address of outgoing multicast to the routing table, and VPN clients commonly claim
the route for `224.0.0.251`. The packets still leave the LAN interface, because `openMulticastSocket`
pins egress with `setNetworkInterface`, but they carry a source address belonging to the tunnel.
Receivers on the link see an off-link source and drop them.

That explains the shape of the bug reported in #203:

- announcements and goodbyes are multicast, so a service registered while a VPN is up never shows up
  elsewhere, and an unregistered one never disappears
- unicast replies are unaffected, so a client that restarts and sends a fresh query does find the
  service, which makes discovery look like it half works
- whether it reproduces depends on the VPN client, matching the original report, since it comes down
  to whether that client takes the multicast route

## The change

Windows on JDK 8 and 11 keeps the wildcard bind, so #356 stays fixed. Everything else binds the host
address, which is the path Windows on JDK 17+ has been running since #363.

## Testing

macOS 26.5.1, OpenJDK 21, Surfshark on WireGuard. With the VPN up, `route -n get 224.0.0.251` reports
a `utun` interface; with it down, `en0`.

Same test program either side, registering one service through
`JmDNS.create(InetAddress.getByName("10.0.0.231"), ...)`. The observer was a Pixel 10 Pro XL on
Android 17 using `NsdManager`, not on the VPN, already browsing `_phovo._tcp` before the service
started, so the result depended on the announcement arriving rather than on a fresh query. An iPhone
using `NSNetService` saw the same thing.

| build | result |
| --- | --- |
| current main | service never discovered |
| this branch | discovered and resolved within seconds |

Apple's `dns-sd -R` was registered on the same host as a control and was always discovered, which
rules out the tunnel simply blocking LAN multicast.

## What I have not tested

Linux, and Windows on any JDK. Linux takes the changed branch, so it would be worth a check before
merging, particularly that multicast reception still works when the socket is bound to a unicast
address. Windows behaviour is unchanged on both JDK ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
